### PR TITLE
Swtich to entity linking

### DIFF
--- a/seq2rel_ds/align/biogrid.py
+++ b/seq2rel_ds/align/biogrid.py
@@ -1,20 +1,18 @@
 import json
 import re
 from enum import Enum
-from itertools import chain
 from math import ceil
 from operator import itemgetter
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
 import pandas as pd
 import spacy
 import typer
-from fuzzywuzzy import fuzz
 from more_itertools import chunked
 from seq2rel_ds import msg
-from seq2rel_ds.align.util import get_pubtator_response, get_uniprot_synonyms, Synonyms, Annotations
-from seq2rel_ds.common.util import fuzzy_match, sanitize_text, set_seeds
+from seq2rel_ds.align.util import get_pubtator_response
+from seq2rel_ds.common.util import sanitize_text, set_seeds
 from spacy.tokens.doc import Doc
 
 app = typer.Typer(callback=set_seeds)
@@ -31,26 +29,18 @@ app = typer.Typer(callback=set_seeds)
 # - include pubtator relations?
 # - use pubtator for retrieving text as well?
 
-INTERACTOR_A_SYMBOL = "Official Symbol Interactor A"
-INTERACTOR_B_SYMBOL = "Official Symbol Interactor B"
-INTERACTOR_A_SYNONYMS = "Synonyms Interactor A"
-INTERACTOR_B_SYNONYMS = "Synonyms Interactor B"
+
+ENTREZGENE_INTERACTOR_A = "Entrez Gene Interactor A"
+ENTREZGENE_INTERACTOR_B = "Entrez Gene Interactor B"
 EXPERIMENTAL_SYSTEM_TYPE = "Experimental System Type"
 PUBLICATION_SOURCE = "Publication Source"
-INTERACTOR_A_UNIPROT_ID = "SWISS-PROT Accessions Interactor A"
-INTERACTOR_B_UNIPROT_ID = "SWISS-PROT Accessions Interactor B"
-BIOGRID_COLS = [
-    INTERACTOR_A_SYMBOL,
-    INTERACTOR_B_SYMBOL,
-    INTERACTOR_A_SYNONYMS,
-    INTERACTOR_B_SYNONYMS,
-    EXPERIMENTAL_SYSTEM_TYPE,
-    PUBLICATION_SOURCE,
-    INTERACTOR_A_UNIPROT_ID,
-    INTERACTOR_B_UNIPROT_ID,
-]
+BIOGRID_COLS = {
+    ENTREZGENE_INTERACTOR_A: pd.StringDtype(),
+    ENTREZGENE_INTERACTOR_B: pd.StringDtype(),
+    EXPERIMENTAL_SYSTEM_TYPE: pd.StringDtype(),
+    PUBLICATION_SOURCE: pd.StringDtype(),
+}
 END_OF_REL_SYMBOL = "@EOR@"
-SYNONYMS_FN = "synonyms.json"
 ANNOTATIONS_FN = "annotations.json"
 BIOGRID_FN = "biogrid.tsv"
 
@@ -60,9 +50,6 @@ UNIPROT_IDS_PER_REQUEST = 1000
 # This is the number of PMIDs per request allowed by pubtators webservice.
 # See: https://www.ncbi.nlm.nih.gov/research/pubtator/api.html for details.
 PMIDS_PER_REQUEST = 1000
-# The number of documents spacy will process in parallel.
-# This was tuned on my local machine.
-SPACY_BATCH_SIZE = 100
 
 
 class TextSegment(str, Enum):
@@ -100,12 +87,17 @@ def _load_scispacy(model: str):
 
 
 def _load_biogrid(biogrid_path_or_url: str) -> pd.DataFrame:
-    df = pd.read_csv(biogrid_path_or_url, sep="\t", usecols=BIOGRID_COLS)
+    df = pd.read_csv(biogrid_path_or_url, sep="\t", usecols=BIOGRID_COLS.keys(), dtype=BIOGRID_COLS)
     return df
 
 
-def _format_rel(interactor_a: str, interactor_b: str, rel_type: str) -> str:
-    return f"@{rel_type.strip().upper()}@ {interactor_a} @PRGE@ {interactor_b} @PRGE@ {END_OF_REL_SYMBOL}"
+def _format_rel(interactor_a: List[str], interactor_b: List[str], rel_type: str) -> str:
+    return (
+        f"@{rel_type.strip().upper()}@"
+        f" {'; '.join(interactor_a).strip()} @PRGE@"
+        f" {'; '.join(interactor_b).strip()} @PRGE@"
+        f" {END_OF_REL_SYMBOL}"
+    )
 
 
 def _get_entities(doc: Doc) -> List[str]:
@@ -129,39 +121,6 @@ def _sort_by_offset(items: List[str], offsets: List[int], **kwargs) -> List[str]
     return sorted_items
 
 
-def _align_row(row, text: str, ents: List[str], synonyms: Dict[str, List[str]]) -> Tuple[str, str]:
-    # Get all the information we need from BioGrid df
-    interactor_a = [row[INTERACTOR_A_SYMBOL]] + row[INTERACTOR_A_SYNONYMS].split("|")
-    interactor_b = [row[INTERACTOR_B_SYMBOL]] + row[INTERACTOR_B_SYNONYMS].split("|")
-    uniprot_id_a = row[INTERACTOR_A_UNIPROT_ID].split("|")
-    uniprot_id_b = row[INTERACTOR_B_UNIPROT_ID].split("|")
-
-    # Expand the list of interactor names with their synonyms
-    interactor_a_synonyms = chain.from_iterable(synonyms[_id] for _id in uniprot_id_a)
-    interactor_b_synonyms = chain.from_iterable(synonyms[_id] for _id in uniprot_id_b)
-    interactor_a.extend(interactor_a_synonyms)
-    interactor_b.extend(interactor_b_synonyms)
-
-    # Remove duplicates (order doesn't matter)
-    interactor_a = list(set(interactor_a))
-    interactor_b = list(set(interactor_b))
-
-    # Fuzzy match the extracted entities to the interactor names
-    interactor_a_match = fuzzy_match(
-        interactor_a, ents, scorer=fuzz.token_sort_ratio, score_cutoff=70, limit=3
-    )
-    interactor_b_match = fuzzy_match(
-        interactor_b, ents, scorer=fuzz.token_sort_ratio, score_cutoff=70, limit=3
-    )
-
-    # TODO: Here, we make a strong assumption that only dimers will contain interactions
-    # between identical entities. There is almost definitely a better way to handle this.
-    if interactor_a_match == interactor_b_match and "dimer" not in text:
-        interactor_a_match, interactor_b_match = "", ""
-
-    return interactor_a_match, interactor_b_match
-
-
 def _align(
     input_dir: Path,
     output_fp: Optional[Path] = None,
@@ -177,15 +136,12 @@ def _align(
     if output_fp:
         output_fp = Path(output_fp)
 
-    synonyms_fp = input_dir / SYNONYMS_FN
     annotations_fp = input_dir / ANNOTATIONS_FN
     biogrid_fp = input_dir / BIOGRID_FN
 
-    synonyms = json.loads(synonyms_fp.read_text())
-    msg.good(f"Loaded synonyms file at: {synonyms_fp}")
     annotations = json.loads(annotations_fp.read_text())
     msg.good(f"Loaded annotations file at: {annotations_fp}")
-    df = pd.read_csv(biogrid_fp, sep="\t")
+    df = pd.read_csv(biogrid_fp, sep="\t", dtype=BIOGRID_COLS)
     msg.good(f"Loaded BioGRID file at: {biogrid_fp}")
 
     if pmid_whitelist:
@@ -194,18 +150,22 @@ def _align(
         pmids = list(annotations.keys())
     msg.info(f"Alignments will be generated from {len(pmids)} PMIDs")
 
-    max_instances = max_instances or len(df)
-    msg.info(f"Total number of alignments will be restricted to {max_instances}")
+    max_instances = max_instances or len(pmids)
+    msg.info(f"Total number of alignments will be restricted to {len(pmids)}")
 
     alignments = {}
     with typer.progressbar(length=max_instances, label="Aligning") as progress:
         for i, pmid in enumerate(pmids):
             if text_segment.value == "both":
                 text = annotations[pmid]["title"]["text"] + annotations[pmid]["abstract"]["text"]
-                ents = annotations[pmid]["title"]["ents"] + annotations[pmid]["abstract"]["ents"]
+                raise ValueError("This won't work, have to add entities correctly.")
+                clusters = (
+                    annotations[pmid]["title"]["clusters"]
+                    + annotations[pmid]["abstract"]["clusters"]
+                )
             else:
                 text = annotations[pmid][text_segment.value]["text"]
-                ents = annotations[pmid][text_segment.value]["ents"]
+                clusters = annotations[pmid][text_segment.value]["clusters"]
 
             rows = df[df[PUBLICATION_SOURCE] == f"PUBMED:{pmid}"]
 
@@ -215,19 +175,21 @@ def _align(
                 # TODO: In the future, it might be nice to try and distinguish between genetic and
                 # physical interactions. For now, we group them into one category.
                 # rel_type = row[EXPERIMENTAL_SYSTEM_TYPE]
-                rel_type = "interaction"
-                interactor_a, interactor_b = _align_row(row, text, ents, synonyms)
+                rel_type = row[EXPERIMENTAL_SYSTEM_TYPE]
+                interactor_a = clusters.get(row[ENTREZGENE_INTERACTOR_A], [])
+                interactor_b = clusters.get(row[ENTREZGENE_INTERACTOR_B], [])
+
                 # If we have a hit for both interactors, accumulate the annotation
                 if interactor_a and interactor_b:
+                    ents_a = interactor_a["ents"]
+                    ents_b = interactor_b["ents"]
                     # Keep track of the end offsets of each entity. We will use these to sort
                     # relations according to their order of first appearence in the text.
-                    offset_a = text.find(interactor_a) + len(interactor_a)
-                    offset_b = text.find(interactor_b) + len(interactor_b)
+                    offset_a = min((end for _, end in interactor_a["offsets"]))
+                    offset_b = min((end for _, end in interactor_b["offsets"]))
                     offset = offset_a + offset_b
-                    interactor_a, interactor_b = _sort_by_offset(
-                        [interactor_a, interactor_b], [offset_a, offset_b]
-                    )
-                    relation = _format_rel(interactor_a, interactor_b, rel_type)
+                    ents_a, ents_b = _sort_by_offset([ents_a, ents_b], [offset_a, offset_b])
+                    relation = _format_rel(ents_a, ents_b, rel_type)
                     # Some very basic text preprocessing to standardize things
                     relation = sanitize_text(relation)
                     # Don't accumulate identical relations
@@ -236,7 +198,6 @@ def _align(
                         offsets.append(offset)
 
             if relations:
-                progress.update(len(relations))
                 # Sort the relations by order of first appearence
                 relations = _sort_by_offset(relations, offsets)
                 relations = " ".join(relations)
@@ -244,9 +205,10 @@ def _align(
                 if output_fp is not None:
                     with open(output_fp, "a") as f:
                         f.write(f"{annotation}\n")
+                progress.update(1)
 
-            # For testing purposes, we still record the pmid even if no relations were found.
-            alignments[pmid] = relations
+                # TODO: This leads to empty entries during testing. Come up with a solution.
+                alignments[pmid] = relations
 
             if len(alignments) == max_instances:
                 break
@@ -307,24 +269,12 @@ def preprocess(
         ...,
         help="A path on disk (or URL) to a tab delineated (*.tab3) BioGRID release",
     ),
-    scispacy_model: str = typer.Option(
-        None, help="The scispaCy model to use for NER and abbreviation resolution"
-    ),
 ):
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     msg.divider("Preprocessing")
-
-    if scispacy_model is not None:
-        nlp = _load_scispacy(scispacy_model)
-        msg.good(f"Loaded scispacy model: {scispacy_model}")
-    else:
-        nlp = None
-        msg.warn(
-            "scispacy_model not provided. This will negatively impact the quality of alignments"
-        )
 
     df = _load_biogrid(biogrid_path_or_url)
     msg.good(f"Loaded BioGRID release: {biogrid_path_or_url}")
@@ -338,22 +288,8 @@ def preprocess(
     pmids = df[PUBLICATION_SOURCE].apply(lambda x: re.search(r"\d+$", x).group()).unique().tolist()
     msg.info(f"Found {len(pmids)} unique PMIDs in the BioGRID release")
 
-    # Get all unique UniProt IDs in the dataframe, account for the compound IDs and duplicates.
-    uniprot_ids = df[INTERACTOR_A_UNIPROT_ID].unique().tolist()
-    uniprot_ids.extend(df[INTERACTOR_B_UNIPROT_ID].unique().tolist())
-    uniprot_ids = [_id for ids in uniprot_ids for _id in ids.split("|")]
-    uniprot_ids = list(set(uniprot_ids))
-
-    # Get synonyms for all UniProt IDs in the dataframe
-    synonyms: Synonyms = {}
-    total_results = ceil(len(uniprot_ids) / UNIPROT_IDS_PER_REQUEST)
-    with typer.progressbar(length=total_results, label="Fetching UniProt synonyms") as progress:
-        for uniprot_ids in chunked(uniprot_ids, UNIPROT_IDS_PER_REQUEST):
-            synonyms.update(get_uniprot_synonyms(uniprot_ids))
-            progress.update(1)
-
     # Get the PubTator results for all PMIDs in the dataframe
-    annotations: Annotations = {}
+    annotations = {}
     total_results = ceil(len(pmids) / PMIDS_PER_REQUEST)
     with typer.progressbar(length=total_results, label="Fetching PubTator annotations") as progress:
         for pmids_ in chunked(pmids, PMIDS_PER_REQUEST):
@@ -361,36 +297,9 @@ def preprocess(
             annotations.update(annotation)
             progress.update(1)
 
-    # If a ScispaCy model was provided, use it to extend the list of entities
-    if nlp is not None:
-        num_batches = ceil(len(annotations) / SPACY_BATCH_SIZE)
-        with typer.progressbar(
-            length=num_batches, label="Extending annotations with ScispaCy"
-        ) as progress:
-            for pmids in chunked(annotations, SPACY_BATCH_SIZE):
-                # Downstream, we may want to compare performance when aligning to titles,
-                # abstracts or both. To keep all options open, we separately keep track of
-                # entities in the title and the abstract.
-                titles = [annotations[pmid]["title"]["text"] for pmid in pmids]
-                abstracts = [annotations[pmid]["abstract"]["text"] for pmid in pmids]
-
-                title_docs = list(nlp.pipe(titles))
-                abstract_docs = list(nlp.pipe(abstracts))
-
-                for pmid, title_doc, abstract_doc in zip(pmids, title_docs, abstract_docs):
-                    annotations[pmid]["title"]["ents"].extend(_get_entities(title_doc))
-                    annotations[pmid]["abstract"]["ents"].extend(_get_entities(abstract_doc))
-                progress.update(1)
-            # We don't need to retain duplicate entities
-            annotations[pmid]["title"]["ents"] = list(set(annotations[pmid]["title"]["ents"]))
-            annotations[pmid]["abstract"]["ents"] = list(set(annotations[pmid]["abstract"]["ents"]))
-
-    synonyms_fp = output_dir / SYNONYMS_FN
     annotations_fp = output_dir / ANNOTATIONS_FN
     biogrid_fp = output_dir / BIOGRID_FN
 
-    synonyms_fp.write_text(json.dumps(synonyms, indent=2))
-    msg.good(f"Saved synonyms file to: {synonyms_fp}")
     annotations_fp.write_text(json.dumps(annotations, indent=2))
     msg.good(f"Saved annotations_fp file to: {annotations_fp}")
     df.to_csv(biogrid_fp, sep="\t")
@@ -405,7 +314,7 @@ def main(
         TextSegment.both, help="Whether to use title text, abstract text, or both"
     ),
     max_instances: int = typer.Option(
-        ..., help="The maximum number of PMIDs to produce alignments for"
+        None, help="The maximum number of PMIDs to produce alignments for"
     ),
 ) -> None:
     """Creates training data for distantly supervised relation extraction by aligning BioGRID

--- a/seq2rel_ds/align/util.py
+++ b/seq2rel_ds/align/util.py
@@ -1,18 +1,13 @@
-import re
-from io import StringIO
-from typing import Dict, List, Optional, Union
+from typing import Optional, List
 
 import requests
 from requests.adapters import HTTPAdapter
 from seq2rel_ds.common.util import sanitize_text
 from urllib3.util.retry import Retry
 
+# API URLs
 UNIPROT_API_URL = "https://www.uniprot.org/uploadlists/"
 PUBTATOR_API_URL = "https://www.ncbi.nlm.nih.gov/research/pubtator-api/publications/export/pubtator"
-
-PROTEIN_NAME_REGEX = r"(?:(?:Full|Short)=)(?!\s)([^{;]*)(?<!\s)"
-GENE_NAME_REGEX = r"(?:Name=)(?!\s)([^{;]*)(?<!\s)"
-GENE_SYNONYMS_REGEX = r"(?:Synonyms=)(?!\s)([^{;]*)(?<!\s)"
 
 # Here, we create a session globally that can be used in all requests. We add a hook that will
 # call raise_for_status() after all our requests. Because API calls can be flaky, we also add
@@ -25,40 +20,12 @@ s.hooks["response"] = [assert_status_hook]
 retries = Retry(total=5, backoff_factor=0.1)
 s.mount("https://", HTTPAdapter(max_retries=retries))
 
-# Some custom types
-Synonyms = Dict[str, List[str]]
-Annotations = Dict[str, Dict[str, Dict[str, Union[str, List[str]]]]]
 
-
-def get_uniprot_synonyms(uniprot_ids: List[str]) -> Synonyms:
-    """Returns a dictionary, keyed by the ids in `uniprot_ids`, containing each ids gene and
-    protein name synonyms.
-    """
-    synonyms = {}
-    # See UniProts REST API for details: https://www.uniprot.org/help/api
-    file = StringIO(" ".join(uniprot_ids))
-    params = {"format": "txt", "from": "ACC+ID", "to": "ACC"}
-    r = s.post(UNIPROT_API_URL, files={"file": file}, params=params)
-    entries = r.text.strip().split("\n//")
-
-    for uniprot_id, entry in zip(uniprot_ids, entries):
-        synonyms[uniprot_id] = []
-        for line in entry.split("\n"):
-            if line.startswith("DE"):
-                synonyms[uniprot_id].extend(re.findall(PROTEIN_NAME_REGEX, line))
-            elif line.startswith("GN"):
-                synonyms[uniprot_id].extend(re.findall(GENE_NAME_REGEX, line))
-                gene_name_syns = re.findall(GENE_SYNONYMS_REGEX, line)
-                if gene_name_syns:
-                    synonyms[uniprot_id].extend(gene_name_syns[0].split(", "))
-    return synonyms
-
-
-def get_pubtator_response(pmids: List[str], concepts: Optional[List[str]] = None) -> Annotations:
-    json_body = {"pmids": pmids}
+def get_pubtator_response(pmids: List[str], concepts: Optional[List[str]] = None):
+    body = {"pmids": pmids}
     if concepts is not None:
-        json_body["concepts"] = concepts
-    r = s.post(PUBTATOR_API_URL, json=json_body)
+        body["concepts"] = concepts
+    r = s.post(PUBTATOR_API_URL, json=body)
     articles = r.text.strip().split("\n\n")
     annotations = {}
     for article in articles:
@@ -71,17 +38,34 @@ def get_pubtator_response(pmids: List[str], concepts: Optional[List[str]] = None
         title = sanitize_text(title)
         abstract = sanitize_text(abstract)
 
-        title_ents, abstract_ents = [], []
-        for ent in ents:
-            ent = ent.strip().split("\t")
-            start, text = ent[1], ent[3]
-            if int(start) < len(title):
-                title_ents.append(text)
-            else:
-                abstract_ents.append(text)
-
         annotations[pmid] = {
-            "title": {"text": title, "ents": title_ents},
-            "abstract": {"text": abstract, "ents": abstract_ents},
+            "title": {"text": title, "clusters": {}},
+            "abstract": {"text": abstract, "clusters": {}},
         }
+
+        for ent in ents:
+            ent_data = ent.strip().split("\t")
+            # A very small number of ents are missing IDs. Skip them.
+            if len(ent_data) < 6:
+                continue
+            _, start, end, text, _, entrezgene = ent_data
+            text = text.lower()
+            start, end = int(start), int(end)
+
+            # Collect entities per section
+            section = "title" if int(start) < len(title) else "abstract"
+
+            if entrezgene in annotations[pmid][section]["clusters"]:
+                # Don't retain duplicates
+                if text not in annotations[pmid][section]["clusters"][entrezgene]["ents"]:
+                    annotations[pmid][section]["clusters"][entrezgene]["ents"].append(text)
+                    annotations[pmid][section]["clusters"][entrezgene]["offsets"].append(
+                        (start, end)
+                    )
+            else:
+                annotations[pmid][section]["clusters"][entrezgene] = {
+                    "ents": [text],
+                    "offsets": [(start, end)],
+                }
+
     return annotations

--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -48,17 +48,15 @@ def fuzzy_match(
 
 def train_valid_test_split(
     data: Iterable[Any],
-    train_size: int = 0.7,
-    valid_size: int = 0.1,
-    test_size: int = 0.2,
+    train_size: float = 0.7,
+    valid_size: float = 0.1,
+    test_size: float = 0.2,
     **kwargs: Any,
 ) -> Tuple[List[Any], List[Any], List[Any]]:
     """Given an iterable (`data`), returns train, valid and test partitions of size `train_size`,
     `valid_size` and `test_size`. Optional kwargs are passed to `sklearn.model_selection.train_test_split`
     """
     # https://datascience.stackexchange.com/a/53161
-    X_train, X_test = train_test_split(data, test_size=1 - train_size, **kwargs)
-    X_valid, X_test = train_test_split(
-        X_test, test_size=test_size / (test_size + valid_size), **kwargs
-    )
-    return X_train, X_valid, X_test
+    train, test = train_test_split(data, test_size=1 - train_size, **kwargs)
+    valid, test = train_test_split(test, test_size=test_size / (test_size + valid_size), **kwargs)
+    return train, valid, test

--- a/tests/align/test_align_util.py
+++ b/tests/align/test_align_util.py
@@ -1,93 +1,6 @@
 from seq2rel_ds.align import util
 
 
-def test_get_uniprot_synonyms_one_id() -> None:
-    """Test that the function works for a single Uniprot ID component names."""
-    expected = {
-        "Q09670": ["Putative NADPH dehydrogenase C5H10.04", "Old yellow enzyme homolog 1"],
-    }
-
-    actual = util.get_uniprot_synonyms(uniprot_ids=list(expected.keys()))
-    assert actual == expected
-
-
-def test_get_uniprot_synonyms_gene_names() -> None:
-    """Test that the function captures gene names."""
-    expected = {
-        "Q86V15": [
-            "Zinc finger protein castor homolog 1",
-            "Castor-related protein",
-            "Putative survival-related protein",
-            "Zinc finger protein 693",
-            "CASZ1",
-            "CST",
-            "SRG",
-            "ZNF693",
-        ],
-    }
-
-    actual = util.get_uniprot_synonyms(uniprot_ids=list(expected.keys()))
-    assert actual == expected
-
-
-def test_get_uniprot_synonyms_ignores_ids() -> None:
-    """Test that any IDs provided as part of the name are ignored."""
-    expected = {
-        "Q20819": ["Elongation factor Ts, mitochondrial", "EF-Ts", "EF-TsMt", "tsfm-1"],
-    }
-    actual = util.get_uniprot_synonyms(uniprot_ids=list(expected.keys()))
-    assert actual == expected
-
-
-def test_get_uniprot_synonyms_component_names() -> None:
-    """Test that the function captures component names."""
-    expected = {
-        "P33587": [
-            "Vitamin K-dependent protein C",
-            "Anticoagulant protein C",
-            "Autoprothrombin IIA",
-            "Blood coagulation factor XIV",
-            "Vitamin K-dependent protein C light chain",
-            "Vitamin K-dependent protein C heavy chain",
-            "Activation peptide",
-            "Proc",
-        ],
-    }
-
-    actual = util.get_uniprot_synonyms(uniprot_ids=list(expected.keys()))
-    assert actual == expected
-
-
-def test_get_uniprot_synonyms_many_ids() -> None:
-    expected = {
-        "Q09670": ["Putative NADPH dehydrogenase C5H10.04", "Old yellow enzyme homolog 1"],
-        "Q86V15": [
-            "Zinc finger protein castor homolog 1",
-            "Castor-related protein",
-            "Putative survival-related protein",
-            "Zinc finger protein 693",
-            "CASZ1",
-            "CST",
-            "SRG",
-            "ZNF693",
-        ],
-        "Q20819": ["Elongation factor Ts, mitochondrial", "EF-Ts", "EF-TsMt", "tsfm-1"],
-        "P33587": [
-            "Vitamin K-dependent protein C",
-            "Anticoagulant protein C",
-            "Autoprothrombin IIA",
-            "Blood coagulation factor XIV",
-            "Vitamin K-dependent protein C light chain",
-            "Vitamin K-dependent protein C heavy chain",
-            "Activation peptide",
-            "Proc",
-        ],
-    }
-
-    actual = util.get_uniprot_synonyms(uniprot_ids=list(expected.keys()))
-    assert actual == expected
-
-
 def test_get_pubtator_response() -> None:
     pmid = "28483577"
     expected = {
@@ -98,7 +11,7 @@ def test_get_pubtator_response() -> None:
                     " deacetylation and anti-inflammatory activities in bronchial epithelial cells"
                     " exposed to cigarette smoke."
                 ),
-                "ents": [],
+                "clusters": {},
             },
             "abstract": {
                 "text": (
@@ -125,17 +38,14 @@ def test_get_pubtator_response() -> None:
                     " some processes related to steroid resistance induced by oxidative stress due to cigarette"
                     " smoke exposure increasing the anti-inflammatory effects of FP."
                 ),
-                "ents": [
-                    "HDAC3",
-                    "HDAC2",
-                    "NF-kappaB",
-                    "IL-8",
-                    "TNF-alpha",
-                    "IL-1beta",
-                    "HDAC3",
-                    "HDAC2",
-                    "NF-kappaB",
-                ],
+                "clusters": {
+                    "8841": {"ents": ["HDAC3"], "offsets": [(921, 926)]},
+                    "3066": {"ents": ["HDAC2"], "offsets": [(931, 936)]},
+                    "4790": {"ents": ["NF-kappaB"], "offsets": [(979, 988)]},
+                    "3576": {"ents": ["IL-8"], "offsets": [(1013, 1017)]},
+                    "7124": {"ents": ["TNF-alpha"], "offsets": [(1019, 1028)]},
+                    "3553": {"ents": ["IL-1beta"], "offsets": [(1030, 1038)]},
+                },
             },
         }
     }

--- a/tests/align/test_align_util.py
+++ b/tests/align/test_align_util.py
@@ -39,12 +39,12 @@ def test_get_pubtator_response() -> None:
                     " smoke exposure increasing the anti-inflammatory effects of FP."
                 ),
                 "clusters": {
-                    "8841": {"ents": ["HDAC3"], "offsets": [(921, 926)]},
-                    "3066": {"ents": ["HDAC2"], "offsets": [(931, 936)]},
-                    "4790": {"ents": ["NF-kappaB"], "offsets": [(979, 988)]},
-                    "3576": {"ents": ["IL-8"], "offsets": [(1013, 1017)]},
-                    "7124": {"ents": ["TNF-alpha"], "offsets": [(1019, 1028)]},
-                    "3553": {"ents": ["IL-1beta"], "offsets": [(1030, 1038)]},
+                    "8841": {"ents": ["hdac3"], "offsets": [(921, 926)]},
+                    "3066": {"ents": ["hdac2"], "offsets": [(931, 936)]},
+                    "4790": {"ents": ["nf-kappab"], "offsets": [(979, 988)]},
+                    "3576": {"ents": ["il-8"], "offsets": [(1013, 1017)]},
+                    "7124": {"ents": ["tnf-alpha"], "offsets": [(1019, 1028)]},
+                    "3553": {"ents": ["il-1beta"], "offsets": [(1030, 1038)]},
                 },
             },
         }


### PR DESCRIPTION
This PR updates the alignment to rely on matching unique IDs (specifically, Entrezgene) as opposed to fuzzy string matching. This dramatically improved the quality of alignments.

There is a lot of functionality that was removed, most notably, extending annotations with scispacy. I will add the scispacy stuff back in a subsequent PR, because it does reduce the number of PMIDs we have to drop due to a missed alignment.