### PR TITLE
Refactor utils

### DIFF
--- a/seq2rel_ds/align/schemas.py
+++ b/seq2rel_ds/align/schemas.py
@@ -1,8 +1,0 @@
-from pydantic import BaseModel
-
-
-class AlignedExample(BaseModel):
-    doc_id: str
-    text: str
-    relations: str
-    score: float

--- a/seq2rel_ds/align/util.py
+++ b/seq2rel_ds/align/util.py
@@ -1,8 +1,10 @@
-from typing import Optional, List
+from typing import Dict, List, Optional
 
 import requests
 from requests.adapters import HTTPAdapter
-from seq2rel_ds.common.util import sanitize_text
+from seq2rel_ds.common import util
+from seq2rel_ds.common.schemas import PubtatorAnnotation
+from seq2rel_ds.common.util import TextSegment
 from urllib3.util.retry import Retry
 
 # API URLs
@@ -20,51 +22,18 @@ retries = Retry(total=5, backoff_factor=0.1)
 s.mount("https://", HTTPAdapter(max_retries=retries))
 
 
-def get_pubtator_response(pmids: List[str], concepts: Optional[List[str]] = None):
+def query_pubtator(
+    pmids: List[str],
+    concepts: Optional[List[str]] = None,
+    text_segment: TextSegment = TextSegment.both,
+    skip_malformed: bool = False,
+) -> Dict[str, PubtatorAnnotation]:
     body = {"pmids": pmids}
     if concepts is not None:
         body["concepts"] = concepts
     r = s.post(PUBTATOR_API_URL, json=body)
-    articles = r.text.strip().split("\n\n")
-    annotations = {}
-    for article in articles:
-        article = article.strip().split("\n")
-        title, abstract, ents = article[0], article[1], article[2:]
-        pmid, title = title.split("|t|")
-        abstract = abstract.split("|a|")[-1]
-
-        # Some very basic preprocessing
-        title = sanitize_text(title)
-        abstract = sanitize_text(abstract)
-
-        annotations[pmid] = {
-            "title": {"text": title, "clusters": {}},
-            "abstract": {"text": abstract, "clusters": {}},
-        }
-
-        for ent in ents:
-            ent_data = ent.strip().split("\t")
-            # A very small number of ents are missing IDs. Skip them.
-            if len(ent_data) < 6:
-                continue
-            _, start, end, text, _, entrezgene = ent_data
-            text = text.lower()
-            start, end = int(start), int(end)
-
-            # Collect entities per section
-            section = "title" if int(start) < len(title) else "abstract"
-
-            if entrezgene in annotations[pmid][section]["clusters"]:
-                # Don't retain duplicates
-                if text not in annotations[pmid][section]["clusters"][entrezgene]["ents"]:
-                    annotations[pmid][section]["clusters"][entrezgene]["ents"].append(text)
-                    annotations[pmid][section]["clusters"][entrezgene]["offsets"].append(
-                        (start, end)
-                    )
-            else:
-                annotations[pmid][section]["clusters"][entrezgene] = {
-                    "ents": [text],
-                    "offsets": [(start, end)],
-                }
-
+    pubtator_content = r.text.strip()
+    annotations = util.parse_pubtator(
+        pubtator_content, text_segment=text_segment, skip_malformed=skip_malformed
+    )
     return annotations

--- a/seq2rel_ds/common/schemas.py
+++ b/seq2rel_ds/common/schemas.py
@@ -1,0 +1,45 @@
+from typing import List, Tuple, Dict
+import json
+
+from pydantic import BaseModel
+
+
+class AlignedExample(BaseModel):
+    doc_id: str
+    text: str
+    relations: str
+    score: float
+
+
+class PubtatorCluster(BaseModel):
+    ents: List[str]
+    offsets: List[Tuple[int, ...]]
+    label: str
+
+
+class PubtatorAnnotation(BaseModel):
+    text: str
+    clusters: Dict[str, PubtatorCluster] = {}
+    relations: List[Tuple[str, ...]] = []
+
+
+class PydanticEncoder(json.JSONEncoder):
+    """A custom encoder so we can call `json` methods on objects with Pydantic models in them
+
+    See: https://docs.python.org/3/library/json.html for more details.
+    """
+
+    def default(self, obj):
+        if isinstance(obj, BaseModel):
+            return obj.dict()
+        # Let the base class default method raise the TypeError
+        return json.JSONEncoder.default(self, obj)
+
+
+def as_pubtator_annotation(dct):
+    """To be used as `object_hook` with `json` methods to load serialized data as
+    `PubtatorAnnotation` objects.
+    """
+    if "text" in dct and "clusters" in dct and "relations" in dct:
+        return PubtatorAnnotation(**dct)
+    return dct

--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -1,11 +1,22 @@
 import random
-from typing import Any, Iterable, List, Tuple
+from enum import Enum
+from operator import itemgetter
+from typing import Any, Dict, Iterable, List, Tuple
 
 import numpy as np
+from seq2rel_ds.common.schemas import PubtatorAnnotation, PubtatorCluster
 from sklearn.model_selection import train_test_split
 
 SEED = 13370
 NUMPY_SEED = 1337
+
+END_OF_REL_SYMBOL = "@EOR@"
+
+
+class TextSegment(str, Enum):
+    title = "title"
+    abstract = "abstract"
+    both = "both"
 
 
 def set_seeds():
@@ -19,6 +30,17 @@ def sanitize_text(text: str, lowercase: bool = False) -> str:
     sanitized_text = " ".join(text.strip().split())
     sanitized_text = sanitized_text.lower() if lowercase else sanitized_text
     return sanitized_text
+
+
+def sort_by_offset(items: List[str], offsets: List[int], **kwargs) -> List[str]:
+    """Returns `items`, sorted in ascending order according to `offsets`"""
+    if len(items) != len(offsets):
+        raise ValueError(f"len(items) ({len(items)}) != len(offsets) ({len(offsets)})")
+    packed = list(zip(items, offsets))
+    packed = sorted(packed, key=itemgetter(1), **kwargs)
+    sorted_items, _ = zip(*packed)
+    sorted_items = list(sorted_items)
+    return sorted_items
 
 
 def train_valid_test_split(
@@ -35,3 +57,99 @@ def train_valid_test_split(
     train, test = train_test_split(data, test_size=1 - train_size, **kwargs)
     valid, test = train_test_split(test, test_size=test_size / (test_size + valid_size), **kwargs)
     return train, valid, test
+
+
+def format_relation(ent_clusters: List[List[str]], ent_labels: List[str], rel_label: str) -> str:
+    """Given an arbitrary number of coreferent mentions (`*args`), a label for each of those
+    mentions (`ent_labels`) and a label for the relation (`rel_label`) returns a formatted string
+    that can be used to train a seq2rel model.
+    """
+    formatted_rel = f"@{rel_label.strip().upper()}@"
+    for ents, label in zip(ent_clusters, ent_labels):
+        ents = sanitize_text("; ".join(ents), lowercase=True)
+        formatted_rel += f" {ents} @{label.strip().upper()}@"
+    formatted_rel += f" {END_OF_REL_SYMBOL}"
+    return formatted_rel
+
+
+def parse_pubtator(
+    pubtator_content: str,
+    text_segment: TextSegment = TextSegment.both,
+    skip_malformed: bool = False,
+) -> Dict[str, PubtatorAnnotation]:
+    """Parses a PubTator format string (`pubtator_content`) returning a highly structured,
+    dictionary keyed by PMID.
+    """
+    # Get a list of PubTator annotations
+    articles = pubtator_content.strip().split("\n\n")
+
+    # Parse the annotations, producing a highly structured output
+    parsed = {}
+    for article in articles:
+        article = article.strip().split("\n")
+        title, abstract, annotations = article[0], article[1], article[2:]
+        pmid, title = title.split("|t|")
+        abstract = abstract.split("|a|")[-1]
+        # Some very basic preprocessing
+        title = sanitize_text(title)
+        abstract = sanitize_text(abstract)
+
+        # We may want to experiement with different text sources
+        if text_segment.value == "both":
+            text = f"{title} {abstract}"
+        elif text_segment.value == "title":
+            text = title
+        else:
+            text = abstract
+
+        parsed[pmid] = PubtatorAnnotation(text=text)
+
+        for ann in annotations:
+            ann = ann.strip().split("\t")
+
+            if len(ann) >= 6:
+                if len(ann) == 6:
+                    _, start, end, texts, label, uids = ann
+                elif len(ann) == 7:
+                    _, start, end, _, label, uids, texts = ann
+                start, end = int(start), int(end)
+
+                # Ignore this annotation if it is not in the chosen text segment
+                section = "title" if int(start) < len(title) else "abstract"
+                if section != text_segment.value and text_segment.value != "both":
+                    continue
+
+                # In at least one corpus (BC5CDR), the annotators include annotations for the
+                # individual entities in a compound entity. So we deal with that here.
+                # Note that the start & end indicies will no longer be exactly correct, but are
+                # be close enough for our purposes of sorting entities by order of appearence.
+                texts, uids = texts.split("|"), uids.split("|")
+
+                for text, uid in zip(texts, uids):
+                    # All entities are lowercased here to simplify the logic downstream.
+                    # They will be lowercased by the copy mechanism anyways.
+                    text = sanitize_text(text, lowercase=True)
+
+                    if uid in parsed[pmid].clusters:
+                        # Don't retain duplicates
+                        if text not in parsed[pmid].clusters[uid].ents:
+                            parsed[pmid].clusters[uid].ents.append(text)
+                            parsed[pmid].clusters[uid].offsets.append((start, end))
+                    else:
+                        parsed[pmid].clusters[uid] = PubtatorCluster(
+                            ents=[text], offsets=[(start, end)], label=label
+                        )
+            elif len(ann) == 4:  # this is a relation
+                _, label, uid_1, uid_2 = ann
+                if uid_1 in parsed[pmid].clusters and uid_2 in parsed[pmid].clusters:
+                    parsed[pmid].relations.append((uid_1, uid_2, label))
+            # For some cases (like distant supervision) it is convient to skip any annotations
+            # that are malformed.
+            else:
+                if skip_malformed:
+                    continue
+                else:
+                    err_msg = "Found an annotation with an unexpected number of columns: {}"
+                    raise ValueError(err_msg.format(format(" ".join(ann))))
+
+    return parsed

--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -52,9 +52,11 @@ def train_valid_test_split(
 ) -> Tuple[List[Any], List[Any], List[Any]]:
     """Given an iterable (`data`), returns train, valid and test partitions of size `train_size`,
     `valid_size` and `test_size`. Optional kwargs are passed to `sklearn.model_selection.train_test_split`
+
+    See https://datascience.stackexchange.com/a/53161 for details.
     """
-    # https://datascience.stackexchange.com/a/53161
-    train, test = train_test_split(data, test_size=1 - train_size, **kwargs)
+    # Round to avoid precision errors.
+    train, test = train_test_split(data, test_size=round(1 - train_size, 4), **kwargs)
     valid, test = train_test_split(test, test_size=test_size / (test_size + valid_size), **kwargs)
     return train, valid, test
 

--- a/tests/align/test_align_util.py
+++ b/tests/align/test_align_util.py
@@ -1,54 +1,93 @@
 from seq2rel_ds.align import util
+from seq2rel_ds.common import schemas
 
 
-def test_get_pubtator_response() -> None:
-    pmid = "28483577"
-    expected = {
-        pmid: {
-            "title": {
-                "text": (
-                    "Formoterol and fluticasone propionate combination improves histone"
-                    " deacetylation and anti-inflammatory activities in bronchial epithelial cells"
-                    " exposed to cigarette smoke."
-                ),
-                "clusters": {},
-            },
-            "abstract": {
-                "text": (
-                    "BACKGROUND: The addition of long-acting beta2-agonists (LABAs) to"
-                    " corticosteroids improves asthma control. Cigarette smoke exposure, increasing"
-                    " oxidative stress, may negatively affect corticosteroid responses."
-                    " The anti-inflammatory effects of formoterol (FO) and fluticasone propionate (FP)"
-                    " in human bronchial epithelial cells exposed to cigarette smoke extracts (CSE) are"
-                    " unknown. AIMS: This study explored whether FP, alone and in combination with FO,"
-                    " in human bronchial epithelial cellline (16-HBE) and primary bronchial epithelial"
-                    " cells (NHBE), counteracted some CSE-mediated effects and in particular some of the"
-                    " molecular mechanisms of corticosteroid resistance. METHODS: 16-HBE and NHBE were"
-                    " stimulated with CSE, FP and FO alone or combined. HDAC3 and HDAC2 activity, nuclear"
-                    " translocation of GR and NF-kappaB, pERK1/2/tERK1/2 ratio, IL-8, TNF-alpha,"
-                    " IL-1beta mRNA expression, and mitochondrial ROS were evaluated. Actin reorganization"
-                    " in neutrophils was assessed by fluorescence microscopy using the phalloidin method."
-                    " RESULTS: In 16-HBE, CSE decreased expression/activity of HDAC3, activity of HDAC2,"
-                    " nuclear translocation of GR and increased nuclear NF-kappaB expression, pERK 1/2/tERK1/2"
-                    " ratio, and mRNA expression of inflammatory cytokines. In NHBE, CSE increased mRNA"
-                    " expression of inflammatory cytokines and supernatants from CSE exposed NHBE increased"
-                    " actin reorganization in neutrophils. FP combined with FO reverted all these phenomena"
-                    " in CSE stimulated 16-HBE cells as well as in NHBE cells. CONCLUSIONS: The present"
-                    " study provides compelling evidences that FP combined with FO may contribute to revert"
-                    " some processes related to steroid resistance induced by oxidative stress due to cigarette"
-                    " smoke exposure increasing the anti-inflammatory effects of FP."
-                ),
-                "clusters": {
-                    "8841": {"ents": ["hdac3"], "offsets": [(921, 926)]},
-                    "3066": {"ents": ["hdac2"], "offsets": [(931, 936)]},
-                    "4790": {"ents": ["nf-kappab"], "offsets": [(979, 988)]},
-                    "3576": {"ents": ["il-8"], "offsets": [(1013, 1017)]},
-                    "7124": {"ents": ["tnf-alpha"], "offsets": [(1019, 1028)]},
-                    "3553": {"ents": ["il-1beta"], "offsets": [(1030, 1038)]},
-                },
-            },
-        }
+def test_query_pubtator() -> None:
+    pmid = "19285439"
+    title_text = (
+        "The ubiquitin ligase RNF5 regulates antiviral responses by mediating degradation"
+        " of the adaptor protein MITA."
+    )
+    abstract_text = (
+        "Viral infection activates transcription factors NF-kappaB and IRF3, which collaborate to"
+        " induce type I interferons (IFNs) and elicit innate antiviral response. MITA (also known"
+        " as STING) has recently been identified as an adaptor that links virus-sensing receptors"
+        " to IRF3 activation. Here, we showed that the E3 ubiquitin ligase RNF5 interacted with"
+        " MITA in a viral-infection-dependent manner. Overexpression of RNF5 inhibited"
+        " virus-triggered IRF3 activation, IFNB1 expression, and cellular antiviral response,"
+        " whereas knockdown of RNF5 had opposite effects. RNF5 targeted MITA at Lys150 for"
+        " ubiquitination and degradation after viral infection. Both MITA and RNF5 were located at"
+        " the mitochondria and endoplasmic reticulum (ER) and viral infection caused their"
+        " redistribution to the ER and mitochondria, respectively. We further found that"
+        " virus-induced ubiquitination and degradation of MITA by RNF5 occurred at the"
+        " mitochondria. These findings suggest that RNF5 negatively regulates virus-triggered"
+        " signaling by targeting MITA for ubiquitination and degradation at the mitochondria."
+    )
+    title_clusters = {
+        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(21, 25)], label="Gene"),
+        "340061": schemas.PubtatorCluster(ents=["mita"], offsets=[(104, 108)], label="Gene"),
+    }
+    abstract_clusters = {
+        "4790": schemas.PubtatorCluster(ents=["nf-kappab"], offsets=[(158, 167)], label="Gene"),
+        "3661": schemas.PubtatorCluster(ents=["irf3"], offsets=[(172, 176)], label="Gene"),
+        "340061": schemas.PubtatorCluster(
+            ents=["mita", "sting"], offsets=[(270, 274), (290, 295)], label="Gene"
+        ),
+        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(440, 444)], label="Gene"),
+        "3456": schemas.PubtatorCluster(ents=["ifnb1"], offsets=[(571, 576)], label="Gene"),
+    }
+    both_clusters = {
+        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(21, 25)], label="Gene"),
+        "340061": schemas.PubtatorCluster(
+            ents=["mita", "sting"], offsets=[(104, 108), (290, 295)], label="Gene"
+        ),
+        "4790": schemas.PubtatorCluster(ents=["nf-kappab"], offsets=[(158, 167)], label="Gene"),
+        "3661": schemas.PubtatorCluster(ents=["irf3"], offsets=[(172, 176)], label="Gene"),
+        "3456": schemas.PubtatorCluster(ents=["ifnb1"], offsets=[(571, 576)], label="Gene"),
     }
 
-    actual = util.get_pubtator_response(pmids=[pmid], concepts=["gene"])
-    assert actual == expected
+    # Title only
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=title_text,
+            clusters=title_clusters,
+            relations=[],
+        ),
+    }
+    actual = util.query_pubtator(
+        pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.title
+    )
+    # Breaking up the asserts leads to much clearer outputs when the test fails
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations
+
+    # Abstract only
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=abstract_text,
+            clusters=abstract_clusters,
+            relations=[],
+        ),
+    }
+    actual = util.query_pubtator(
+        pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.abstract
+    )
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations
+
+    # Both
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=f"{title_text} {abstract_text}",
+            clusters=both_clusters,
+            relations=[],
+        ),
+    }
+    actual = util.query_pubtator(
+        pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.both
+    )
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations

--- a/tests/align/test_biogrid.py
+++ b/tests/align/test_biogrid.py
@@ -1,0 +1,2 @@
+def test_main() -> None:
+    pass

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -1,0 +1,17 @@
+from seq2rel_ds.common import schemas
+import json
+
+
+def test_pydantic_encoder(dummy_annotation_pydantic) -> None:
+    # This is a pretty shallow test, but it will throw an error if the object cannot be serialized.
+    _ = json.dumps(dummy_annotation_pydantic, indent=2, cls=schemas.PydanticEncoder)
+
+
+def test_as_pubtator_annotation(dummy_annotation_json) -> None:
+    actual = json.loads(dummy_annotation_json, object_hook=schemas.as_pubtator_annotation)
+    for pmid, annotation in actual.items():
+        assert isinstance(pmid, str)
+        assert isinstance(annotation, schemas.PubtatorAnnotation)
+        for uid, cluster in annotation.clusters.items():
+            assert isinstance(uid, str)
+            assert isinstance(cluster, schemas.PubtatorCluster)

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -1,10 +1,18 @@
 from seq2rel_ds.common import schemas
 import json
+import pytest
 
 
 def test_pydantic_encoder(dummy_annotation_pydantic) -> None:
     # This is a pretty shallow test, but it will throw an error if the object cannot be serialized.
     _ = json.dumps(dummy_annotation_pydantic, indent=2, cls=schemas.PydanticEncoder)
+
+
+def test_pydantic_encoder_type_error(dummy_annotation_pydantic) -> None:
+    # Exactly what we pass here doesn't matter, so long as it is not JSON seriablizable.
+    non_serializable = {"arbitrary": 3 + 6j}
+    with pytest.raises(TypeError):
+        _ = json.dumps(non_serializable, indent=2, cls=schemas.PydanticEncoder)
 
 
 def test_as_pubtator_annotation(dummy_annotation_json) -> None:

--- a/tests/common/util/test_common_util.py
+++ b/tests/common/util/test_common_util.py
@@ -1,3 +1,4 @@
+import random
 import re
 
 import numpy as np
@@ -52,13 +53,24 @@ def test_sort_by_offset_raise_value_error() -> None:
         _ = util.sort_by_offset(items, offsets)
 
 
+def test_train_valid_test_split():
+    data = random.sample(range(0, 100), 10)
+    train_size, valid_size, test_size = 0.7, 0.1, 0.2
+    train, valid, test = util.train_valid_test_split(
+        data, train_size=train_size, valid_size=valid_size, test_size=test_size
+    )
+    assert len(train) == int(train_size * len(data))
+    assert len(valid) == int(valid_size * len(data))
+    assert len(test) == int(test_size * len(data))
+
+
 def test_format_relation() -> None:
     # Add trailing and leading spaces throughout to ensure they are handled.
     rel_label = "Interaction "
     ent_clusters = [["MITA ", "STING"], [" NF-kappaB"], ["IRF3"]]
-    ent_labels = ["PRGE", " PRGE", "PRGE "]
+    ent_labels = ["GGP", " GGP", "GGP "]
     expected = (
-        f"@INTERACTION@ mita ; sting @PRGE@ nf-kappab @PRGE@ irf3 @PRGE@ {util.END_OF_REL_SYMBOL}"
+        f"@INTERACTION@ mita ; sting @GGP@ nf-kappab @GGP@ irf3 @GGP@ {util.END_OF_REL_SYMBOL}"
     )
     actual = util.format_relation(
         ent_clusters=ent_clusters, ent_labels=ent_labels, rel_label=rel_label

--- a/tests/common/util/test_common_util.py
+++ b/tests/common/util/test_common_util.py
@@ -1,9 +1,10 @@
 import re
 
 import numpy as np
+import pytest
 from hypothesis import given
 from hypothesis.strategies import booleans, text
-from seq2rel_ds.common import util
+from seq2rel_ds.common import schemas, util
 
 
 def test_set_seeds() -> None:
@@ -29,3 +30,153 @@ def test_sanitize_text(text: str, lowercase: bool) -> None:
     # Only run if the generated text can be lowercased.
     if lowercase and text.lower().islower():
         assert all(not char.isupper() for char in sanitized_text)
+
+
+def test_sort_by_offset() -> None:
+    items = ["b", "c", "a"]
+    offsets = [1, 2, 0]
+
+    expected = ["a", "b", "c"]
+    actual = util.sort_by_offset(items, offsets)
+
+    assert actual == expected
+    # Check that we did not mutate the input
+    assert items == ["b", "c", "a"]
+
+
+def test_sort_by_offset_raise_value_error() -> None:
+    items = ["b", "c", "a"]
+    offsets = [1, 2]
+
+    with pytest.raises(ValueError):
+        _ = util.sort_by_offset(items, offsets)
+
+
+def test_format_relation() -> None:
+    # Add trailing and leading spaces throughout to ensure they are handled.
+    rel_label = "Interaction "
+    ent_clusters = [["MITA ", "STING"], [" NF-kappaB"], ["IRF3"]]
+    ent_labels = ["PRGE", " PRGE", "PRGE "]
+    expected = (
+        f"@INTERACTION@ mita ; sting @PRGE@ nf-kappab @PRGE@ irf3 @PRGE@ {util.END_OF_REL_SYMBOL}"
+    )
+    actual = util.format_relation(
+        ent_clusters=ent_clusters, ent_labels=ent_labels, rel_label=rel_label
+    )
+    assert actual == expected
+
+
+def test_parse_pubtator_raises_value_error() -> None:
+    pmid = "2339463"
+    title_text = "Cerebral sinus thrombosis as a potential hazard of antifibrinolytic treatment in menorrhagia."
+    abstract_text = (
+        "We describe a 42-year-old woman who developed superior sagittal and left transverse sinus"
+        " thrombosis associated with prolonged epsilon-aminocaproic acid therapy for menorrhagia."
+    )
+    pubtator_content = f"""
+    {pmid}|t|{title_text}
+    {pmid}|a|{abstract_text}
+    {pmid}	0	25	Cerebral sinus thrombosis	Disease
+    """
+
+    # There should be no error when skip_malformed is True...
+    _ = util.parse_pubtator(pubtator_content, skip_malformed=True)
+    # ...and and error when it is False
+    with pytest.raises(ValueError):
+        _ = util.parse_pubtator(pubtator_content, skip_malformed=False)
+
+
+def test_parse_pubtator() -> None:
+    # An example taken from the BC5CDR dataset
+    pmid = "2339463"
+    title_text = "Cerebral sinus thrombosis as a potential hazard of antifibrinolytic treatment in menorrhagia."
+    abstract_text = (
+        "We describe a 42-year-old woman who developed superior sagittal and left transverse sinus"
+        " thrombosis associated with prolonged epsilon-aminocaproic acid therapy for menorrhagia."
+    )
+    pubtator_content = f"""
+    {pmid}|t|{title_text}
+    {pmid}|a|{abstract_text}
+    {pmid}	0	25	Cerebral sinus thrombosis	Disease	D012851
+    {pmid}	81	92	menorrhagia	Disease	D008595
+    {pmid}	149	194	sagittal and left transverse sinus thrombosis	Disease	D020225|D020227	sagittal sinus thrombosis|left transverse sinus thrombosis
+    {pmid}	221	246	epsilon-aminocaproic acid	Chemical	D015119
+    {pmid}	CID	D015119	D020225
+    """
+
+    title_clusters = {
+        "D012851": schemas.PubtatorCluster(
+            ents=["cerebral sinus thrombosis"], offsets=[(0, 25)], label="Disease"
+        ),
+        "D008595": schemas.PubtatorCluster(
+            ents=["menorrhagia"], offsets=[(81, 92)], label="Disease"
+        ),
+    }
+    abstract_clusters = {
+        "D020225": schemas.PubtatorCluster(
+            ents=["sagittal sinus thrombosis"], offsets=[(149, 194)], label="Disease"
+        ),
+        "D020227": schemas.PubtatorCluster(
+            ents=["left transverse sinus thrombosis"], offsets=[(149, 194)], label="Disease"
+        ),
+        "D015119": schemas.PubtatorCluster(
+            ents=["epsilon-aminocaproic acid"], offsets=[(221, 246)], label="Chemical"
+        ),
+    }
+    both_clusters = {
+        "D012851": schemas.PubtatorCluster(
+            ents=["cerebral sinus thrombosis"], offsets=[(0, 25)], label="Disease"
+        ),
+        "D008595": schemas.PubtatorCluster(
+            ents=["menorrhagia"], offsets=[(81, 92)], label="Disease"
+        ),
+        "D020225": schemas.PubtatorCluster(
+            ents=["sagittal sinus thrombosis"], offsets=[(149, 194)], label="Disease"
+        ),
+        "D020227": schemas.PubtatorCluster(
+            ents=["left transverse sinus thrombosis"], offsets=[(149, 194)], label="Disease"
+        ),
+        "D015119": schemas.PubtatorCluster(
+            ents=["epsilon-aminocaproic acid"], offsets=[(221, 246)], label="Chemical"
+        ),
+    }
+
+    # Title only
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=title_text,
+            clusters=title_clusters,
+            relations=[],
+        ),
+    }
+    actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.title)
+    # Breaking up the asserts leads to much clearer outputs when the test fails
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations
+
+    # Abstract only
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=abstract_text,
+            clusters=abstract_clusters,
+            relations=[("D015119", "D020225", "CID")],
+        ),
+    }
+    actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.abstract)
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations
+
+    # Both
+    expected = {
+        pmid: schemas.PubtatorAnnotation(
+            text=f"{title_text} {abstract_text}",
+            clusters=both_clusters,
+            relations=[("D015119", "D020225", "CID")],
+        ),
+    }
+    actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.both)
+    assert actual[pmid].text == expected[pmid].text
+    assert actual[pmid].clusters == expected[pmid].clusters
+    assert actual[pmid].relations == expected[pmid].relations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+import copy
+import json
+from typing import Any, Dict
+
+import pytest
+from seq2rel_ds.common.schemas import PubtatorAnnotation, PubtatorCluster
+
+
+@pytest.fixture
+def dummy_annotation_dict() -> Dict[str, Any]:
+    annotation = {
+        "2038333": {
+            "text": (
+                "Mutations of yeast CYC8 or TUP1 genes greatly reduce the degree of glucose repression"
+                " of many genes and affect other regulatory pathways, including mating type."
+            ),
+            "clusters": {
+                "852410": {"ents": ["cyc8"], "offsets": [[142, 146]], "label": "Gene"},
+                "850445": {"ents": ["tup1"], "offsets": [[150, 154]], "label": "Gene"},
+            },
+            "relations": [],
+        },
+    }
+
+    return annotation
+
+
+@pytest.fixture()
+def dummy_annotation_json(dummy_annotation_dict) -> str:
+    return json.dumps(dummy_annotation_dict)
+
+
+@pytest.fixture()
+def dummy_annotation_pydantic(dummy_annotation_dict) -> Dict[str, PubtatorAnnotation]:
+    annotation = copy.deepcopy(dummy_annotation_dict)
+
+    for pmid in annotation:
+        for uid in annotation[pmid]["clusters"]:
+            annotation[pmid]["clusters"][uid] = PubtatorCluster(**annotation[pmid]["clusters"][uid])
+        annotation[pmid] = PubtatorAnnotation(**annotation[pmid])
+    return annotation


### PR DESCRIPTION
This PR is a major refactor of `common/util.py` and `align/util.py`. These changes were made mainly to consolidate code that is used by both the `preprocess` and the `align` submodules under `common/util.py`. In the near future, I am going to use this to clean up the scripts under `align`. This also adds a bunch of tests increasing test coverage.