### PR TITLE
Cleanup BC5CDR script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
       - name: Test with pytest
         run: |
           poetry run pytest tests --cov-report=xml --cov ./seq2rel_ds --cov-config=.coveragerc
-      - name: Upload coverage to CodeClimate
-        # We don't want to push coverge for every job in the matrix.
-        # Rather arbitrarily, choose to push on Ubuntu with Python 3.7.
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.3.2
         with:
           file: ./coverage.xml

--- a/poetry.lock
+++ b/poetry.lock
@@ -177,7 +177,7 @@ toml = ["toml"]
 
 [[package]]
 name = "datasets"
-version = "1.6.0"
+version = "1.6.1"
 description = "HuggingFace/Datasets is an open library of NLP datasets."
 category = "main"
 optional = false
@@ -200,13 +200,13 @@ xxhash = "*"
 [package.extras]
 apache-beam = ["apache-beam (>=2.26.0)"]
 benchmarks = ["numpy (==1.18.5)", "tensorflow (==2.3.0)", "torch (==1.6.0)", "transformers (==3.0.2)"]
-dev = ["absl-py", "pytest", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore (==1.2.2)", "boto3 (==1.16.43)", "botocore (==1.19.52)", "faiss-cpu", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs", "tensorflow (>=2.3)", "torch", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "sklearn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "wget (>=3.2)", "pytorch-nlp (==0.5.0)", "pytorch-lightning", "fastBPE (==0.1.0)", "fairseq", "black", "isort", "flake8 (==3.7.9)"]
+dev = ["absl-py", "pytest", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore (==1.2.2)", "boto3 (==1.16.43)", "botocore (==1.19.52)", "faiss-cpu", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs", "tensorflow (>=2.3)", "torch", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "sklearn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "wget (>=3.2)", "pytorch-nlp (==0.5.0)", "pytorch-lightning", "fastBPE (==0.1.0)", "fairseq", "black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)", "importlib-resources"]
 docs = ["docutils (==0.16.0)", "recommonmark", "sphinx (==3.1.2)", "sphinx-markdown-tables", "sphinx-rtd-theme (==0.4.3)", "sphinxext-opengraph (==0.4.1)", "sphinx-copybutton", "fsspec", "s3fs"]
-quality = ["black", "isort", "flake8 (==3.7.9)"]
+quality = ["black (==21.4b0)", "flake8 (==3.7.9)", "isort", "pyyaml (>=5.3.1)"]
 s3 = ["fsspec", "boto3 (==1.16.43)", "botocore (==1.19.52)", "s3fs"]
 tensorflow = ["tensorflow (>=2.2.0)"]
 tensorflow_gpu = ["tensorflow-gpu (>=2.2.0)"]
-tests = ["absl-py", "pytest", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore (==1.2.2)", "boto3 (==1.16.43)", "botocore (==1.19.52)", "faiss-cpu", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs", "tensorflow (>=2.3)", "torch", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "sklearn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "wget (>=3.2)", "pytorch-nlp (==0.5.0)", "pytorch-lightning", "fastBPE (==0.1.0)", "fairseq"]
+tests = ["absl-py", "pytest", "pytest-xdist", "apache-beam (>=2.26.0)", "elasticsearch", "aiobotocore (==1.2.2)", "boto3 (==1.16.43)", "botocore (==1.19.52)", "faiss-cpu", "fsspec", "moto[s3,server] (==2.0.4)", "rarfile (>=4.0)", "s3fs", "tensorflow (>=2.3)", "torch", "transformers", "bs4", "conllu", "langdetect", "lxml", "mwparserfromhell", "nltk", "openpyxl", "py7zr", "tldextract", "zstandard", "bert-score (>=0.3.6)", "rouge-score", "sacrebleu", "scipy", "seqeval", "sklearn", "jiwer", "sentencepiece", "toml (>=0.10.1)", "requests-file (>=1.5.1)", "tldextract (>=3.1.0)", "texttable (>=1.6.3)", "Werkzeug (>=1.0.1)", "wget (>=3.2)", "pytorch-nlp (==0.5.0)", "pytorch-lightning", "fastBPE (==0.1.0)", "fairseq", "importlib-resources"]
 torch = ["torch"]
 
 [[package]]
@@ -573,7 +573,7 @@ testing = ["pytest"]
 
 [[package]]
 name = "hypothesis"
-version = "6.10.0"
+version = "6.10.1"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -584,7 +584,7 @@ attrs = ">=19.2.0"
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
+all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-resources (>=3.3.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2020.4)"]
 cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
 dateutil = ["python-dateutil (>=1.4)"]
@@ -1249,7 +1249,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "de3b364d2bdad21df2aab8a31bcebdccf2e55c20b8a93c1e19da954247d13e49"
+content-hash = "c905cf3f85f4f59e82702b8f375b7eefbc15b6b3baec31de74c17ffefaa8d917"
 
 [metadata.files]
 aiofiles = [
@@ -1402,8 +1402,8 @@ coverage = [
     {file = "coverage-5.5.tar.gz", hash = "sha256:ebe78fe9a0e874362175b02371bdfbee64d8edc42a044253ddf4ee7d3c15212c"},
 ]
 datasets = [
-    {file = "datasets-1.6.0-py3-none-any.whl", hash = "sha256:aa451d915aef63ea87de43f4f42f8ef8655a3d4928581a37e78bf858c73df500"},
-    {file = "datasets-1.6.0.tar.gz", hash = "sha256:086a92972a6a33526fcd94f3ecdc3bc7df9d24ec99c64928479220b061a607dd"},
+    {file = "datasets-1.6.1-py3-none-any.whl", hash = "sha256:f810d3fdbf8a21b000d635d4b0ea3b5252b24c86d0e26fcd9d7c2251dd871c31"},
+    {file = "datasets-1.6.1.tar.gz", hash = "sha256:24d4888c54620aa12200ce405f1ead24b3b20b66b9d815fe1947bed371b8af2e"},
 ]
 dephell = [
     {file = "dephell-0.8.3-py3-none-any.whl", hash = "sha256:3ca3661e2a353b5c67c77034b69b379e360d4c70ce562e8161db32d39064be5a"},
@@ -1505,8 +1505,8 @@ huggingface-hub = [
     {file = "huggingface_hub-0.0.8.tar.gz", hash = "sha256:be5b9a7ed36437bb10a780d500154d426798ec16803ff3406f7a61107e4ebfc2"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.10.0-py3-none-any.whl", hash = "sha256:1a00a4e3ef40041b2c072deab9c71e307bc5354bb4a102ef22ae8c23fa8b3970"},
-    {file = "hypothesis-6.10.0.tar.gz", hash = "sha256:9f8c130b1278d30cb3cc64e3a4aacb88c4906155772beed90ce33e06794e1ee0"},
+    {file = "hypothesis-6.10.1-py3-none-any.whl", hash = "sha256:1d65f58d82d1cbd35b6441bda3bb11cb1adc879d6b2af191aea388fa412171b1"},
+    {file = "hypothesis-6.10.1.tar.gz", hash = "sha256:586b6c46e90878c2546743afbed348bca51e1f30e3461fa701fad58c2c47c650"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,11 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
-exclude = ["tests"]
+exclude = ["tests", "test_fixtures"]
 
 [tool.poetry.dependencies]
+# Have to pin this to avoid errors reported by poetry
+pyarrow = "<4.0.0"
 python = "^3.7.1"
 datasets = "^1.2.1"
 more-itertools = "^8.7.0"

--- a/seq2rel_ds/align/biogrid.py
+++ b/seq2rel_ds/align/biogrid.py
@@ -14,11 +14,10 @@ from seq2rel_ds.common.util import (
     TextSegment,
     format_relation,
     sanitize_text,
-    set_seeds,
     sort_by_offset,
 )
 
-app = typer.Typer(callback=set_seeds)
+app = typer.Typer()
 
 
 ENTREZGENE_INTERACTOR_A = "Entrez Gene Interactor A"

--- a/seq2rel_ds/align/main.py
+++ b/seq2rel_ds/align/main.py
@@ -1,8 +1,13 @@
 import typer
 
 from seq2rel_ds.align import biogrid
+from seq2rel_ds.common.util import set_seeds
 
-app = typer.Typer()
+set_seeds()
+
+app = typer.Typer(
+    help="Commands for creating data for distantly supervised learning in the seq2rel format.",
+)
 app.add_typer(biogrid.app, name="biogrid")
 
 if __name__ == "__main__":

--- a/seq2rel_ds/common/testing/__init__.py
+++ b/seq2rel_ds/common/testing/__init__.py
@@ -1,0 +1,1 @@
+from seq2rel_ds.common.testing.test_case import Seq2RelDSTestCase

--- a/seq2rel_ds/common/testing/test_case.py
+++ b/seq2rel_ds/common/testing/test_case.py
@@ -1,0 +1,13 @@
+import pathlib
+
+
+class Seq2RelDSTestCase:
+    """A custom testing case that contains any logic that might be shared across tests"""
+
+    PROJECT_ROOT = (pathlib.Path(__file__).parent / ".." / ".." / "..").resolve()
+    MODULE_ROOT = PROJECT_ROOT / "seq2rel_ds"
+    TESTS_ROOT = PROJECT_ROOT / "tests"
+    FIXTURES_ROOT = PROJECT_ROOT / "test_fixtures"
+
+    def setup_method(self):
+        pass

--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -19,7 +19,7 @@ class TextSegment(str, Enum):
     both = "both"
 
 
-def set_seeds():
+def set_seeds() -> None:
     """Sets the random seeds of python and numpy for reproducible preprocessing."""
     random.seed(SEED)
     np.random.seed(NUMPY_SEED)

--- a/seq2rel_ds/main.py
+++ b/seq2rel_ds/main.py
@@ -3,7 +3,9 @@ import seq2rel_ds.align.main as align
 import seq2rel_ds.preprocess.main as preprocess
 from seq2rel_ds.common.util import set_seeds
 
-app = typer.Typer(callback=set_seeds)
+set_seeds()
+
+app = typer.Typer()
 app.add_typer(align.app, name="align")
 app.add_typer(preprocess.app, name="preprocess")
 

--- a/seq2rel_ds/preprocess/ade.py
+++ b/seq2rel_ds/preprocess/ade.py
@@ -4,18 +4,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import typer
 from datasets import load_dataset
-from seq2rel_ds.common.util import set_seeds, train_valid_test_split
+from seq2rel_ds.common.util import train_valid_test_split
 
 DatasetLine = Dict[str, Any]
 
-app = typer.Typer(
-    callback=set_seeds,
-    name="ade",
-    help=(
-        "Downloads and caches the ADE V2 Corpus from HuggingFace Datasets and preprocesses it for"
-        "use with seq2rel. See https://oro.open.ac.uk/48109/ for more details on the corpus."
-    ),
-)
+app = typer.Typer()
 
 
 def format_adverse_drug_reaction(drug: str, effect: str) -> str:
@@ -79,15 +72,9 @@ def preprocess_ade_v2() -> List[str]:
     return processed_examples
 
 
-@app.command(name="ade")
+@app.callback(invoke_without_command=True)
 def main(output_dir: Path, sorting: Optional[str] = None) -> None:
-    """Downloads and preprocesses the Adverse Drug Reaction corpus for use with seq2rel.
-
-    We make several assumptions:\n
-        - If a sentence is labelled for the same relation more than once, we retain only one annotation.\n
-        - Some entries do not contain entity offsets. In this case, we use the first appearence of\n
-        the entity in the text to determine its offset.
-    """
+    """Download and preprocess the ADE V2 corpus for use with seq2rel."""
     dataset = preprocess_ade_v2()
     train, valid, test = train_valid_test_split(dataset)
 

--- a/seq2rel_ds/preprocess/bc5cdr.py
+++ b/seq2rel_ds/preprocess/bc5cdr.py
@@ -1,145 +1,71 @@
-from operator import itemgetter
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import List
 
 import typer
-from seq2rel_ds.common.util import set_seeds
+from seq2rel_ds.common import util
 
-app = typer.Typer(callback=set_seeds)
+app = typer.Typer()
 
 TRAIN_FILENAME = "CDR_TrainingSet.PubTator.txt"
 VALID_FILENAME = "CDR_DevelopmentSet.PubTator.txt"
 TEST_FILENAME = "CDR_TestSet.PubTator.txt"
 
 
-def format_entity(ent_text: str, ent_type: str):
-    return f"{ent_text} <{ent_type.upper()}>"
+def _preprocess_bc5cdr(filepath: Path) -> List[str]:
+    pubtator_content = Path(filepath).read_text()
+    parsed = util.parse_pubtator(
+        pubtator_content=pubtator_content, text_segment=util.TextSegment.both
+    )
 
-
-def format_relation(ent_1_text, ent_1_type, ent_2_text, ent_2_type, rel_type):
-    ent_1 = format_entity(ent_1_text, ent_1_type)
-    ent_2 = format_entity(ent_2_text, ent_2_type)
-    return f"<{rel_type.upper()}> {ent_1} {ent_2} </{rel_type.upper()}>"
-
-
-def parse_entity(annotation: List[str]) -> List[Tuple[str, str, str, str, str]]:
-    """Returns each entity in `annotation` as a list of tuples containing the end index, entity
-    text, entity type, and entity ID.
-    """
-    entities = []
-    # This is a simple entity that may have one or more IDs.
-    if len(annotation) == 6:
-        _, ent_start, _, ent_texts, ent_type, ent_ids = annotation
-        ent_ids = ent_ids.split("|")
-        ent_texts = [ent_texts] * len(ent_ids)
-    # This is a nested entity with multiple IDs.
-    else:
-        _, ent_start, _, _, ent_type, ent_ids, ent_texts = annotation
-        ent_ids = ent_ids.split("|")
-        ent_texts = ent_texts.split("|")
-
-    offset = int(ent_start)
-    for ent_id, ent_text in zip(ent_ids, ent_texts):
-        ent_start, ent_end = offset, offset + len(ent_text)
-        entities.append((ent_start, ent_end, ent_text, ent_type, ent_id))
-
-    return entities
-
-
-def parse_relation(annotation: str, entities: Dict[str, Any]):
-    """Formats the relation contained in `annotation`, resolving the IDs using `entities`."""
-    _, rel_type, ent_1_id, ent_2_id = annotation
-    (
-        _,
-        ent_1_end,
-        ent_1_text,
-        ent_1_type,
-    ) = entities[ent_1_id]
-    _, ent_2_end, ent_2_text, ent_2_type = entities[ent_2_id]
-
-    relation = format_relation(ent_1_text, ent_1_type, ent_2_text, ent_2_type, rel_type)
-    offset = ent_1_end + ent_2_end
-    to_pop = [ent_1_id, ent_2_id]
-
-    return relation, offset, to_pop
-
-
-def unpack_chunk(chunk: List[str]):
-    lines = chunk.split("\n")
-
-    title = lines[0].split("|")[-1]
-    abstract = lines[1].split("|")[-1]
-
-    entities = {}
-    relations, offsets, ent_ids_to_pop = [], [], []
-
-    for line in lines[2:]:
-        if not line:
-            continue
-        annotation = line.split("\t")
-        if len(annotation) > 4:  # this is an entity
-            for entity in parse_entity(annotation):
-                # Some entities don't have unique identifiers. Retain all of them.
-                ent_start, ent_end, ent_text, ent_type, ent_id = entity
-                if ent_id == "-1":
-                    entities[ent_text] = (ent_start, ent_end, ent_text, ent_type)
-                # Otherwise retain the first mention of each entity.
-                elif ent_id not in entities:
-                    entities[ent_id] = (ent_start, ent_end, ent_text, ent_type)
-        else:  # this is a relation
-            relation, offset, to_pop = parse_relation(annotation, entities)
-            # Don't retain relations that are otherwise identical except for entity offsets or case.
-            if relation.lower() not in map(str.lower, relations):
-                relations.append(relation)
-                offsets.append(offset)
-                ent_ids_to_pop.extend(to_pop)
-
-    # Remove entities already accounted for by relation annotations.
-    for ent_id in ent_ids_to_pop:
-        entities.pop(ent_id, None)
-
-    entities = [format_entity(*entity[2:]) for entity in entities.values()]
-
-    return title, abstract, entities, relations, offsets
-
-
-def preprocess_bc5cdr(filepath: str) -> List[str]:
-
-    # Step 1: Process the dataset chunk by chunk, collecting formatted relations and their offsets.
     processed_dataset = []
-    chunks = Path(filepath).read_text().split("\n\n")
-    with typer.progressbar(chunks, label="Processing") as progress:
-        for chunk in progress:
-            if not chunk:
-                continue
-            title, abstract, entities, relations, offsets = unpack_chunk(chunk)
 
-            # Pack, sort, and unpack relations and their offsets
-            relations = list(zip(*[relations, offsets]))
-            relations.sort(key=itemgetter(1))
-            relations, _ = list(zip(*relations))
+    for annotation in parsed.values():
+        relations = []
+        offsets = []
 
-            # Take the text to be the abstract and the title.
-            text = f"{title} {abstract}"
-            # Take the annotation to be the entities and the relations
-            annotation = " ".join(entities + list(relations))
+        for rel in annotation.relations:
+            uid_1, uid_2, rel_label = rel
+            # Keep track of the end offsets of each entity. We will use these to sort
+            # relations according to their order of first appearence in the text.
+            offset_1 = min((end for _, end in annotation.clusters[uid_1].offsets))
+            offset_2 = min((end for _, end in annotation.clusters[uid_2].offsets))
+            offset = offset_1 + offset_2
+            ent_clusters = [annotation.clusters[uid_1].ents, annotation.clusters[uid_2].ents]
+            ent_labels = [annotation.clusters[uid_1].label, annotation.clusters[uid_2].label]
+            relation = util.format_relation(
+                ent_clusters=ent_clusters,
+                ent_labels=ent_labels,
+                rel_label=rel_label,
+            )
+            relations.append(relation)
+            offsets.append(offset)
 
-            processed_dataset.append(f"{text}\t{annotation}")
+        relations = util.sort_by_offset(relations, offsets)
+        processed_dataset.append(f"{annotation.text}\t{' '.join(relations)}")
 
     return processed_dataset
 
 
-@app.command(name="bc5cdr")
-def main(input_dir: Path, output_dir: str) -> None:
+@app.callback(invoke_without_command=True)
+def main(
+    input_dir: Path = typer.Argument(..., help="Path to a local copy of the BC5CDR corpus."),
+    output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
+) -> None:
+    """Given a path to a local copy of the BC5CDR corpus (`input_dir`), saves a preprocessed copy
+    of the data to `output_dir` that can be used to train a model with the seq2rel package.
+
+    See https://github.com/JohnGiorgi/seq2rel for more details on the seq2rel package and
+    https://pubmed.ncbi.nlm.nih.gov/27161011/ for more details on the BC5CDR corpus.
+    """
     train_filepath = Path(input_dir) / TRAIN_FILENAME
     dev_filepath = Path(input_dir) / VALID_FILENAME
     test_filepath = Path(input_dir) / TEST_FILENAME
 
-    train = preprocess_bc5cdr(train_filepath)
-    valid = preprocess_bc5cdr(dev_filepath)
-    test = preprocess_bc5cdr(test_filepath)
+    train = _preprocess_bc5cdr(train_filepath)
+    valid = _preprocess_bc5cdr(dev_filepath)
+    test = _preprocess_bc5cdr(test_filepath)
 
-    output_dir: Path = Path(output_dir)
+    output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     (output_dir / "train.tsv").write_text("\n".join(train))

--- a/seq2rel_ds/preprocess/bc5cdr.py
+++ b/seq2rel_ds/preprocess/bc5cdr.py
@@ -51,12 +51,7 @@ def main(
     input_dir: Path = typer.Argument(..., help="Path to a local copy of the BC5CDR corpus."),
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
 ) -> None:
-    """Given a path to a local copy of the BC5CDR corpus (`input_dir`), saves a preprocessed copy
-    of the data to `output_dir` that can be used to train a model with the seq2rel package.
-
-    See https://github.com/JohnGiorgi/seq2rel for more details on the seq2rel package and
-    https://pubmed.ncbi.nlm.nih.gov/27161011/ for more details on the BC5CDR corpus.
-    """
+    """Preprocess a local copy of the BC5CDR corpus for use with seq2rel."""
     train_filepath = Path(input_dir) / TRAIN_FILENAME
     dev_filepath = Path(input_dir) / VALID_FILENAME
     test_filepath = Path(input_dir) / TEST_FILENAME

--- a/seq2rel_ds/preprocess/main.py
+++ b/seq2rel_ds/preprocess/main.py
@@ -2,10 +2,12 @@ import typer
 
 from seq2rel_ds.preprocess import ade
 from seq2rel_ds.preprocess import bc5cdr
+from seq2rel_ds.common.util import set_seeds
+
+set_seeds()
 
 app = typer.Typer(
-    name="preprocess",
-    help="A set of commands for preprocessing data to conform to the seq2rel format.",
+    help="Commands for preprocessing data to conform to the seq2rel format.",
 )
 app.add_typer(ade.app, name="ade")
 app.add_typer(bc5cdr.app, name="bc5cdr")

--- a/setup.py
+++ b/setup.py
@@ -46,12 +46,15 @@ setup(
         'Typing :: Typed'
     ],
     entry_points={"console_scripts": ["seq2rel-ds = seq2rel_ds.main:app"]},
-    packages=['seq2rel_ds', 'seq2rel_ds.align', 'seq2rel_ds.preprocess'],
+    packages=[
+        'seq2rel_ds', 'seq2rel_ds.align', 'seq2rel_ds.common.testing',
+        'seq2rel_ds.preprocess'
+    ],
     package_dir={"": "."},
     package_data={},
     install_requires=[
         'datasets==1.*,>=1.2.1', 'more-itertools==8.*,>=8.7.0',
-        'pandas==1.*,>=1.2.1', 'pydantic==1.*,>=1.8.1',
+        'pandas==1.*,>=1.2.1', 'pyarrow<4.0.0', 'pydantic==1.*,>=1.8.1',
         'scikit-learn==0.*,>=0.24.1', 'typer==0.*,>=0.3.2',
         'wasabi==0.*,>=0.8.2'
     ],

--- a/test_fixtures/preprocess/bc5cdr/CDR_DevelopmentSet.PubTator.txt
+++ b/test_fixtures/preprocess/bc5cdr/CDR_DevelopmentSet.PubTator.txt
@@ -1,0 +1,22 @@
+6794356|t|Tricuspid valve regurgitation and lithium carbonate toxicity in a newborn infant.
+6794356|a|A newborn with massive tricuspid regurgitation, atrial flutter, congestive heart failure, and a high serum lithium level is described. This is the first patient to initially manifest tricuspid regurgitation and atrial flutter, and the 11th described patient with cardiac disease among infants exposed to lithium compounds in the first trimester of pregnancy. Sixty-three percent of these infants had tricuspid valve involvement. Lithium carbonate may be a factor in the increasing incidence of congenital heart disease when taken during early pregnancy. It also causes neurologic depression, cyanosis, and cardiac arrhythmia when consumed prior to delivery.
+6794356	0	29	Tricuspid valve regurgitation	Disease	D014262
+6794356	34	51	lithium carbonate	Chemical	D016651
+6794356	52	60	toxicity	Disease	D064420
+6794356	105	128	tricuspid regurgitation	Disease	D014262
+6794356	130	144	atrial flutter	Disease	D001282
+6794356	146	170	congestive heart failure	Disease	D006333
+6794356	189	196	lithium	Chemical	D008094
+6794356	265	288	tricuspid regurgitation	Disease	D014262
+6794356	293	307	atrial flutter	Disease	D001282
+6794356	345	360	cardiac disease	Disease	D006331
+6794356	386	393	lithium	Chemical	D008094
+6794356	511	528	Lithium carbonate	Chemical	D016651
+6794356	576	600	congenital heart disease	Disease	D006331
+6794356	651	672	neurologic depression	Disease	D003866
+6794356	674	682	cyanosis	Disease	D003490
+6794356	688	706	cardiac arrhythmia	Disease	D001145
+6794356	CID	D016651	D003490
+6794356	CID	D016651	D001145
+6794356	CID	D016651	D003866
+

--- a/test_fixtures/preprocess/bc5cdr/CDR_TestSet.PubTator.txt
+++ b/test_fixtures/preprocess/bc5cdr/CDR_TestSet.PubTator.txt
@@ -1,0 +1,15 @@
+8701013|t|Famotidine-associated delirium. A series of six cases.
+8701013|a|Famotidine is a histamine H2-receptor antagonist used in inpatient settings for prevention of stress ulcers and is showing increasing popularity because of its low cost. Although all of the currently available H2-receptor antagonists have shown the propensity to cause delirium, only two previously reported cases have been associated with famotidine. The authors report on six cases of famotidine-associated delirium in hospitalized patients who cleared completely upon removal of famotidine. The pharmacokinetics of famotidine are reviewed, with no change in its metabolism in the elderly population seen. The implications of using famotidine in elderly persons are discussed.
+8701013	0	10	Famotidine	Chemical	D015738
+8701013	22	30	delirium	Disease	D003693
+8701013	55	65	Famotidine	Chemical	D015738
+8701013	156	162	ulcers	Disease	D014456
+8701013	324	332	delirium	Disease	D003693
+8701013	395	405	famotidine	Chemical	D015738
+8701013	442	452	famotidine	Chemical	D015738
+8701013	464	472	delirium	Disease	D003693
+8701013	537	547	famotidine	Chemical	D015738
+8701013	573	583	famotidine	Chemical	D015738
+8701013	689	699	famotidine	Chemical	D015738
+8701013	CID	D015738	D003693
+

--- a/test_fixtures/preprocess/bc5cdr/CDR_TrainingSet.PubTator.txt
+++ b/test_fixtures/preprocess/bc5cdr/CDR_TrainingSet.PubTator.txt
@@ -1,0 +1,34 @@
+227508|t|Naloxone reverses the antihypertensive effect of clonidine.
+227508|a|In unanesthetized, spontaneously hypertensive rats the decrease in blood pressure and heart rate produced by intravenous clonidine, 5 to 20 micrograms/kg, was inhibited or reversed by nalozone, 0.2 to 2 mg/kg. The hypotensive effect of 100 mg/kg alpha-methyldopa was also partially reversed by naloxone. Naloxone alone did not affect either blood pressure or heart rate. In brain membranes from spontaneously hypertensive rats clonidine, 10(-8) to 10(-5) M, did not influence stereoselective binding of [3H]-naloxone (8 nM), and naloxone, 10(-8) to 10(-4) M, did not influence clonidine-suppressible binding of [3H]-dihydroergocryptine (1 nM). These findings indicate that in spontaneously hypertensive rats the effects of central alpha-adrenoceptor stimulation involve activation of opiate receptors. As naloxone and clonidine do not appear to interact with the same receptor site, the observed functional antagonism suggests the release of an endogenous opiate by clonidine or alpha-methyldopa and the possible role of the opiate in the central control of sympathetic tone.
+227508	0	8	Naloxone	Chemical	D009270
+227508	49	58	clonidine	Chemical	D003000
+227508	93	105	hypertensive	Disease	D006973
+227508	181	190	clonidine	Chemical	D003000
+227508	244	252	nalozone	Chemical	-1
+227508	274	285	hypotensive	Disease	D007022
+227508	306	322	alpha-methyldopa	Chemical	D008750
+227508	354	362	naloxone	Chemical	D009270
+227508	364	372	Naloxone	Chemical	D009270
+227508	469	481	hypertensive	Disease	D006973
+227508	487	496	clonidine	Chemical	D003000
+227508	563	576	[3H]-naloxone	Chemical	-1
+227508	589	597	naloxone	Chemical	D009270
+227508	637	646	clonidine	Chemical	D003000
+227508	671	695	[3H]-dihydroergocryptine	Chemical	-1
+227508	750	762	hypertensive	Disease	D006973
+227508	865	873	naloxone	Chemical	D009270
+227508	878	887	clonidine	Chemical	D003000
+227508	1026	1035	clonidine	Chemical	D003000
+227508	1039	1055	alpha-methyldopa	Chemical	D008750
+227508	CID	D008750	D007022
+
+354896|t|Lidocaine-induced cardiac asystole.
+354896|a|Intravenous administration of a single 50-mg bolus of lidocaine in a 67-year-old man resulted in profound depression of the activity of the sinoatrial and atrioventricular nodal pacemakers. The patient had no apparent associated conditions which might have predisposed him to the development of bradyarrhythmias; and, thus, this probably represented a true idiosyncrasy to lidocaine.
+354896	0	9	Lidocaine	Chemical	D008012
+354896	18	34	cardiac asystole	Disease	D006323
+354896	90	99	lidocaine	Chemical	D008012
+354896	142	152	depression	Disease	D003866
+354896	331	347	bradyarrhythmias	Disease	D001919
+354896	409	418	lidocaine	Chemical	D008012
+354896	CID	D008012	D006323
+

--- a/tests/preprocess/test_bc5cdr.py
+++ b/tests/preprocess/test_bc5cdr.py
@@ -1,5 +1,10 @@
-from seq2rel_ds.preprocess import bc5cdr
+from pathlib import Path
+
 from seq2rel_ds.common.testing import Seq2RelDSTestCase
+from seq2rel_ds.preprocess import bc5cdr
+from typer.testing import CliRunner
+
+runner = CliRunner()
 
 
 class TestBC5CDR(Seq2RelDSTestCase):
@@ -86,18 +91,21 @@ class TestBC5CDR(Seq2RelDSTestCase):
         actual = bc5cdr._preprocess_bc5cdr(self.test_path)
         assert actual == self.test
 
-    def test_bc5cdr_command(self, tmp_path) -> None:
-        """This is effectively an integration test."""
-        bc5cdr.main(input_dir=self.data_dir, output_dir=tmp_path)
+    def test_bc5cdr_command(self, tmp_path: Path) -> None:
+
+        input_dir = str(self.data_dir)
+        output_dir = str(tmp_path)
+        result = runner.invoke(bc5cdr.app, [input_dir, output_dir])
+        assert result.exit_code == 0
 
         # training data
         actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
         assert actual == self.train
 
         # validation data
-        actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
-        assert actual == self.train
+        actual = (tmp_path / "valid.tsv").read_text().strip().split("\n")
+        assert actual == self.valid
 
         # test data
-        actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
-        assert actual == self.train
+        actual = (tmp_path / "test.tsv").read_text().strip().split("\n")
+        assert actual == self.test

--- a/tests/preprocess/test_bc5cdr.py
+++ b/tests/preprocess/test_bc5cdr.py
@@ -1,0 +1,103 @@
+from seq2rel_ds.preprocess import bc5cdr
+from seq2rel_ds.common.testing import Seq2RelDSTestCase
+
+
+class TestBC5CDR(Seq2RelDSTestCase):
+    def setup_method(self) -> None:
+        super().setup_method()
+        self.data_dir = self.FIXTURES_ROOT / "preprocess" / "bc5cdr"
+        self.train_path = self.data_dir / bc5cdr.TRAIN_FILENAME
+        self.valid_path = self.data_dir / bc5cdr.VALID_FILENAME
+        self.test_path = self.data_dir / bc5cdr.TEST_FILENAME
+
+        # The expected data, after preprocessing, for each partition
+        self.train = [
+            (
+                "Naloxone reverses the antihypertensive effect of clonidine. In unanesthetized,"
+                " spontaneously hypertensive rats the decrease in blood pressure and heart rate"
+                " produced by intravenous clonidine, 5 to 20 micrograms/kg, was inhibited or reversed"
+                " by nalozone, 0.2 to 2 mg/kg. The hypotensive effect of 100 mg/kg alpha-methyldopa was"
+                " also partially reversed by naloxone. Naloxone alone did not affect either blood"
+                " pressure or heart rate. In brain membranes from spontaneously hypertensive rats"
+                " clonidine, 10(-8) to 10(-5) M, did not influence stereoselective binding of"
+                " [3H]-naloxone (8 nM), and naloxone, 10(-8) to 10(-4) M, did not influence"
+                " clonidine-suppressible binding of [3H]-dihydroergocryptine (1 nM). These findings"
+                " indicate that in spontaneously hypertensive rats the effects of central"
+                " alpha-adrenoceptor stimulation involve activation of opiate receptors. As naloxone"
+                " and clonidine do not appear to interact with the same receptor site, the observed"
+                " functional antagonism suggests the release of an endogenous opiate by clonidine or"
+                " alpha-methyldopa and the possible role of the opiate in the central control of"
+                " sympathetic tone."
+                "\t@CID@ alpha-methyldopa @CHEMICAL@ hypotensive @DISEASE@ @EOR@"
+            ),
+            (
+                "Lidocaine-induced cardiac asystole. Intravenous administration of a single 50-mg bolus"
+                " of lidocaine in a 67-year-old man resulted in profound depression of the activity of"
+                " the sinoatrial and atrioventricular nodal pacemakers. The patient had no apparent"
+                " associated conditions which might have predisposed him to the development of"
+                " bradyarrhythmias; and, thus, this probably represented a true idiosyncrasy to"
+                " lidocaine."
+                "\t@CID@ lidocaine @CHEMICAL@ cardiac asystole @DISEASE@ @EOR@"
+            ),
+        ]
+        self.valid = [
+            (
+                "Tricuspid valve regurgitation and lithium carbonate toxicity in a newborn infant."
+                " A newborn with massive tricuspid regurgitation, atrial flutter, congestive heart"
+                " failure, and a high serum lithium level is described. This is the first patient"
+                " to initially manifest tricuspid regurgitation and atrial flutter, and the 11th"
+                " described patient with cardiac disease among infants exposed to lithium compounds"
+                " in the first trimester of pregnancy. Sixty-three percent of these infants had"
+                " tricuspid valve involvement. Lithium carbonate may be a factor in the increasing"
+                " incidence of congenital heart disease when taken during early pregnancy. It also"
+                " causes neurologic depression, cyanosis, and cardiac arrhythmia when consumed"
+                " prior to delivery."
+                "\t@CID@ lithium carbonate @CHEMICAL@ neurologic depression @DISEASE@ @EOR@"
+                " @CID@ lithium carbonate @CHEMICAL@ cyanosis @DISEASE@ @EOR@"
+                " @CID@ lithium carbonate @CHEMICAL@ cardiac arrhythmia @DISEASE@ @EOR@"
+            )
+        ]
+        self.test = [
+            (
+                "Famotidine-associated delirium. A series of six cases. Famotidine is a histamine"
+                " H2-receptor antagonist used in inpatient settings for prevention of stress ulcers"
+                " and is showing increasing popularity because of its low cost. Although all of the"
+                " currently available H2-receptor antagonists have shown the propensity to cause"
+                " delirium, only two previously reported cases have been associated with"
+                " famotidine. The authors report on six cases of famotidine-associated delirium in"
+                " hospitalized patients who cleared completely upon removal of famotidine. The"
+                " pharmacokinetics of famotidine are reviewed, with no change in its metabolism in"
+                " the elderly population seen. The implications of using famotidine in elderly"
+                " persons are discussed."
+                "\t@CID@ famotidine @CHEMICAL@ delirium @DISEASE@ @EOR@"
+            )
+        ]
+
+    def test_preprocess_bc5cdr(self) -> None:
+        # training data
+        actual = bc5cdr._preprocess_bc5cdr(self.train_path)
+        assert actual == self.train
+
+        # validation data
+        actual = bc5cdr._preprocess_bc5cdr(self.valid_path)
+        assert actual == self.valid
+
+        # test data
+        actual = bc5cdr._preprocess_bc5cdr(self.test_path)
+        assert actual == self.test
+
+    def test_bc5cdr_command(self, tmp_path) -> None:
+        """This is effectively an integration test."""
+        bc5cdr.main(input_dir=self.data_dir, output_dir=tmp_path)
+
+        # training data
+        actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
+        assert actual == self.train
+
+        # validation data
+        actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
+        assert actual == self.train
+
+        # test data
+        actual = (tmp_path / "train.tsv").read_text().strip().split("\n")
+        assert actual == self.train


### PR DESCRIPTION
# Overview

This PR significantly cleans up the BC5CDR script. It also adds a couple of QOL improvements, like better CLI documentation. Also, previously one would have to type `seq2rel-ds preprocess bc5cdr bc5cdr`, but this has been fixed (it's now `seq2rel-ds preprocess bc5cdr`)

## TODO

- [x] Add tests for BC5CDR
- ~~[x] Figure out why the number of processed examples != the expected value~~ Tracking this in #13.