### PR TITLE
Retain all offsets

### DIFF
--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -171,10 +171,11 @@ def parse_pubtator(
                     text = sanitize_text(text, lowercase=True)
 
                     if uid in parsed[pmid].clusters:
-                        # Don't retain duplicates
+                        # Don't retain duplicate text...
                         if text not in parsed[pmid].clusters[uid].ents:
                             parsed[pmid].clusters[uid].ents.append(text)
-                            parsed[pmid].clusters[uid].offsets.append((start, end))
+                        # ...but do retain offsets of all mentions
+                        parsed[pmid].clusters[uid].offsets.append((start, end))
                     else:
                         parsed[pmid].clusters[uid] = PubtatorCluster(
                             ents=[text], offsets=[(start, end)], label=label
@@ -183,8 +184,8 @@ def parse_pubtator(
                 _, label, uid_1, uid_2 = split_ann
                 if uid_1 in parsed[pmid].clusters and uid_2 in parsed[pmid].clusters:
                     parsed[pmid].relations.append((uid_1, uid_2, label))
-            # For some cases (like distant supervision) it is convient to skip any annotations
-            # that are malformed.
+            # For some cases (like distant supervision) it is convient to
+            # skip annotations that are malformed.
             else:
                 if skip_malformed:
                     continue

--- a/tests/align/test_align_util.py
+++ b/tests/align/test_align_util.py
@@ -25,25 +25,79 @@ def test_query_pubtator() -> None:
         " signaling by targeting MITA for ubiquitination and degradation at the mitochondria."
     )
     title_clusters = {
-        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(21, 25)], label="Gene"),
+        "6048": schemas.PubtatorCluster(
+            ents=["rnf5"],
+            offsets=[(21, 25)],
+            label="Gene",
+        ),
         "340061": schemas.PubtatorCluster(ents=["mita"], offsets=[(104, 108)], label="Gene"),
     }
     abstract_clusters = {
         "4790": schemas.PubtatorCluster(ents=["nf-kappab"], offsets=[(158, 167)], label="Gene"),
-        "3661": schemas.PubtatorCluster(ents=["irf3"], offsets=[(172, 176)], label="Gene"),
-        "340061": schemas.PubtatorCluster(
-            ents=["mita", "sting"], offsets=[(270, 274), (290, 295)], label="Gene"
+        "3661": schemas.PubtatorCluster(
+            ents=["irf3"], offsets=[(172, 176), (378, 382), (554, 558)], label="Gene"
         ),
-        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(440, 444)], label="Gene"),
+        "340061": schemas.PubtatorCluster(
+            ents=["mita", "sting"],
+            offsets=[
+                (270, 274),
+                (290, 295),
+                (461, 465),
+                (684, 688),
+                (762, 766),
+                (1000, 1004),
+                (1136, 1140),
+            ],
+            label="Gene",
+        ),
+        "6048": schemas.PubtatorCluster(
+            ents=["rnf5"],
+            offsets=[
+                (440, 444),
+                (523, 527),
+                (643, 647),
+                (670, 674),
+                (771, 775),
+                (1008, 1012),
+                (1071, 1075),
+            ],
+            label="Gene",
+        ),
         "3456": schemas.PubtatorCluster(ents=["ifnb1"], offsets=[(571, 576)], label="Gene"),
     }
     both_clusters = {
-        "6048": schemas.PubtatorCluster(ents=["rnf5"], offsets=[(21, 25)], label="Gene"),
+        "6048": schemas.PubtatorCluster(
+            ents=["rnf5"],
+            offsets=[
+                (21, 25),
+                (440, 444),
+                (523, 527),
+                (643, 647),
+                (670, 674),
+                (771, 775),
+                (1008, 1012),
+                (1071, 1075),
+            ],
+            label="Gene",
+        ),
         "340061": schemas.PubtatorCluster(
-            ents=["mita", "sting"], offsets=[(104, 108), (290, 295)], label="Gene"
+            ents=["mita", "sting"],
+            offsets=[
+                (104, 108),
+                (270, 274),
+                (290, 295),
+                (461, 465),
+                (684, 688),
+                (762, 766),
+                (1000, 1004),
+                (1136, 1140),
+            ],
+            label="Gene",
         ),
         "4790": schemas.PubtatorCluster(ents=["nf-kappab"], offsets=[(158, 167)], label="Gene"),
-        "3661": schemas.PubtatorCluster(ents=["irf3"], offsets=[(172, 176)], label="Gene"),
+        "3661": schemas.PubtatorCluster(
+            ents=["irf3"], offsets=[(172, 176), (378, 382), (554, 558)], label="Gene"
+        ),
         "3456": schemas.PubtatorCluster(ents=["ifnb1"], offsets=[(571, 576)], label="Gene"),
     }
 

--- a/tests/common/util/test_common_util.py
+++ b/tests/common/util/test_common_util.py
@@ -89,6 +89,7 @@ def test_format_relation() -> None:
 
 
 def test_parse_pubtator_raises_value_error() -> None:
+    # A truncated example taken from the BC5CDR dataset
     pmid = "2339463"
     title_text = "Cerebral sinus thrombosis as a potential hazard of antifibrinolytic treatment in menorrhagia."
     abstract_text = (
@@ -109,57 +110,59 @@ def test_parse_pubtator_raises_value_error() -> None:
 
 
 def test_parse_pubtator() -> None:
-    # An example taken from the BC5CDR dataset
-    pmid = "2339463"
-    title_text = "Cerebral sinus thrombosis as a potential hazard of antifibrinolytic treatment in menorrhagia."
+    # A truncated example taken from the BC5CDR dataset
+    pmid = "18020536"
+    title_text = (
+        "Associations between use of benzodiazepines or related drugs and health, physical"
+        " abilities and cognitive function: a non-randomised clinical study in the elderly."
+    )
     abstract_text = (
-        "We describe a 42-year-old woman who developed superior sagittal and left transverse sinus"
-        " thrombosis associated with prolonged epsilon-aminocaproic acid therapy for menorrhagia."
+        "OBJECTIVE: To describe associations between the use of benzodiazepines or related drugs"
+        " (BZDs/RDs) and health, functional abilities and cognitive function in the elderly."
+        " METHODS: A non-randomised clinical study of patients aged > or =65 years admitted to"
+        " acute hospital wards during 1 month. 164 patients (mean age +/- standard deviation [SD]"
+        " 81.6 +/- 6.8 years) were admitted. Of these, nearly half (n = 78) had used BZDs/RDs"
+        " before admission, and the remainder (n = 86) were non-users. Cognitive ability was"
+        " assessed by the Mini-Mental State Examination (MMSE). Patients scoring > or =20 MMSE"
+        " sum points were interviewed (n = 79) and questioned regarding symptoms and functional"
+        " abilities during the week prior to admission."
     )
     pubtator_content = f"""
     {pmid}|t|{title_text}
     {pmid}|a|{abstract_text}
-    {pmid}\t0\t25\tCerebral sinus thrombosis\tDisease\tD012851
-    {pmid}\t81\t92\tmenorrhagia\tDisease\tD008595
-    {pmid}\t149\t194\tsagittal and left transverse sinus thrombosis\tDisease\tD020225|D020227\tsagittal sinus thrombosis|left transverse sinus thrombosis
-    {pmid}\t221\t246\tepsilon-aminocaproic acid\tChemical\tD015119
-    {pmid}\tCID\tD015119\tD020225
+    {pmid}\t28\t43\tbenzodiazepines\tChemical\tD001569
+    {pmid}\t219\t234\tbenzodiazepines\tChemical\tD001569
+    {pmid}\t253\t257\tBZDs\tChemical\tD001569
+    {pmid}\t583\t587\tBZDs\tChemical\tD001569
+    {pmid}\t1817\t1826\ttiredness\tDisease\tD005221
+    {pmid}\tCID\tD001569\tD005221
     """
 
     title_clusters = {
-        "D012851": schemas.PubtatorCluster(
-            ents=["cerebral sinus thrombosis"], offsets=[(0, 25)], label="Disease"
-        ),
-        "D008595": schemas.PubtatorCluster(
-            ents=["menorrhagia"], offsets=[(81, 92)], label="Disease"
+        "D001569": schemas.PubtatorCluster(
+            ents=["benzodiazepines"],
+            offsets=[(28, 43)],
+            label="Chemical",
         ),
     }
     abstract_clusters = {
-        "D020225": schemas.PubtatorCluster(
-            ents=["sagittal sinus thrombosis"], offsets=[(149, 194)], label="Disease"
+        "D001569": schemas.PubtatorCluster(
+            ents=["benzodiazepines", "bzds"],
+            offsets=[(219, 234), (253, 257), (583, 587)],
+            label="Chemical",
         ),
-        "D020227": schemas.PubtatorCluster(
-            ents=["left transverse sinus thrombosis"], offsets=[(149, 194)], label="Disease"
-        ),
-        "D015119": schemas.PubtatorCluster(
-            ents=["epsilon-aminocaproic acid"], offsets=[(221, 246)], label="Chemical"
+        "D005221": schemas.PubtatorCluster(
+            ents=["tiredness"], offsets=[(1817, 1826)], label="Disease"
         ),
     }
     both_clusters = {
-        "D012851": schemas.PubtatorCluster(
-            ents=["cerebral sinus thrombosis"], offsets=[(0, 25)], label="Disease"
+        "D001569": schemas.PubtatorCluster(
+            ents=["benzodiazepines", "bzds"],
+            offsets=[(28, 43), (219, 234), (253, 257), (583, 587)],
+            label="Chemical",
         ),
-        "D008595": schemas.PubtatorCluster(
-            ents=["menorrhagia"], offsets=[(81, 92)], label="Disease"
-        ),
-        "D020225": schemas.PubtatorCluster(
-            ents=["sagittal sinus thrombosis"], offsets=[(149, 194)], label="Disease"
-        ),
-        "D020227": schemas.PubtatorCluster(
-            ents=["left transverse sinus thrombosis"], offsets=[(149, 194)], label="Disease"
-        ),
-        "D015119": schemas.PubtatorCluster(
-            ents=["epsilon-aminocaproic acid"], offsets=[(221, 246)], label="Chemical"
+        "D005221": schemas.PubtatorCluster(
+            ents=["tiredness"], offsets=[(1817, 1826)], label="Disease"
         ),
     }
 
@@ -182,7 +185,7 @@ def test_parse_pubtator() -> None:
         pmid: schemas.PubtatorAnnotation(
             text=abstract_text,
             clusters=abstract_clusters,
-            relations=[("D015119", "D020225", "CID")],
+            relations=[("D001569", "D005221", "CID")],
         ),
     }
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.abstract)
@@ -195,7 +198,7 @@ def test_parse_pubtator() -> None:
         pmid: schemas.PubtatorAnnotation(
             text=f"{title_text} {abstract_text}",
             clusters=both_clusters,
-            relations=[("D015119", "D020225", "CID")],
+            relations=[("D001569", "D005221", "CID")],
         ),
     }
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.both)


### PR DESCRIPTION
Previously, in `parse_pubtator`, we were retaining only the character offsets of the first appearance of an entity, not all offsets. Although we only use the offsets of the first mention for seq2rel, its important to retain all offsets for other purposes (e.g. computing corpus statistics). I fixed this, and updated the tests to check that all offsets are retained.