### PR TITLE
Compute corpus statistics

### DIFF
--- a/seq2rel_ds/common/schemas.py
+++ b/seq2rel_ds/common/schemas.py
@@ -4,6 +4,18 @@ import json
 from pydantic import BaseModel
 
 
+class PartitionStatistics(BaseModel):
+    num_examples: int
+    num_relations: int
+    per_inter_sent: float
+
+
+class CorpusStatistics(BaseModel):
+    train: PartitionStatistics
+    valid: PartitionStatistics
+    test: PartitionStatistics
+
+
 class AlignedExample(BaseModel):
     doc_id: str
     text: str

--- a/seq2rel_ds/preprocess/bc5cdr.py
+++ b/seq2rel_ds/preprocess/bc5cdr.py
@@ -1,12 +1,14 @@
 import io
+import json
 import zipfile
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import requests
 import typer
 from seq2rel_ds import msg
 from seq2rel_ds.common import util
+from seq2rel_ds.common import schemas
 
 app = typer.Typer()
 
@@ -15,6 +17,17 @@ PARENT_DIR = "CDR_Data/CDR.Corpus.v010516"
 TRAIN_FILENAME = "CDR_TrainingSet.PubTator.txt"
 VALID_FILENAME = "CDR_DevelopmentSet.PubTator.txt"
 TEST_FILENAME = "CDR_TestSet.PubTator.txt"
+
+
+def _download_corpus() -> Tuple[str, str, str]:
+    # https://stackoverflow.com/a/23419450/6578628
+    r = requests.get(BC5CDR_URL)
+    z = zipfile.ZipFile(io.BytesIO(r.content))
+    train = z.read(str(Path(PARENT_DIR) / TRAIN_FILENAME)).decode("utf8")
+    valid = z.read(str(Path(PARENT_DIR) / VALID_FILENAME)).decode("utf8")
+    test = z.read(str(Path(PARENT_DIR) / TEST_FILENAME)).decode("utf8")
+
+    return train, valid, test
 
 
 def _preprocess(pubtator_content: str) -> List[str]:
@@ -26,33 +39,67 @@ def _preprocess(pubtator_content: str) -> List[str]:
     return seq2rel_annotations
 
 
-@app.callback(invoke_without_command=True)
+@app.command()
+def compute_stats(
+    output_dir: Path = typer.Argument(..., help="Directory path to save the corpus statistics")
+):
+    """Compute corpus statistics for the BC5CDR corpus."""
+    msg.divider("Corpus statistics for BC5CDR")
+
+    with msg.loading("Downloading corpus..."):
+        train_raw, valid_raw, test_raw = _download_corpus()
+    msg.good("Downloaded the corpus")
+
+    with msg.loading("Computing corpus statistics..."):
+        import spacy
+
+        nlp = spacy.load("en_core_sci_sm", disable=["ner"])
+
+        train = util.parse_pubtator(
+            pubtator_content=train_raw, text_segment=util.TextSegment.both, sort_ents=True
+        )
+        valid = util.parse_pubtator(
+            pubtator_content=valid_raw, text_segment=util.TextSegment.both, sort_ents=True
+        )
+        test = util.parse_pubtator(
+            pubtator_content=test_raw, text_segment=util.TextSegment.both, sort_ents=True
+        )
+
+        train_stats = util.compute_corpus_statistics(train, nlp=nlp)
+        valid_stats = util.compute_corpus_statistics(valid, nlp=nlp)
+        test_stats = util.compute_corpus_statistics(test, nlp=nlp)
+
+    corpus_statistics = schemas.CorpusStatistics(
+        train=train_stats, valid=valid_stats, test=test_stats
+    )
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_fp = output_dir / "corpus_statistics.json"
+    with output_fp.open(mode="w") as f:
+        json.dump(corpus_statistics.dict(), f, indent=2)
+    msg.good(f"Corpus statistics saved to {output_dir.resolve()}")
+
+
+@app.callback(invoke_without_command=True, context_settings={"ignore_unknown_options": True})
 def main(
-    output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
+    ctx: typer.Context,
+    output_dir: str = typer.Argument(..., help="Directory path to save the preprocessed data."),
 ) -> None:
-    """Preprocess a local copy of the BC5CDR corpus for use with seq2rel."""
+    """Download and preprocess the BC5CDR corpus for use with seq2rel."""
+    if ctx.invoked_subcommand is not None:
+        return
+
     msg.divider("Preprocessing BC5CDR")
 
     with msg.loading("Downloading corpus..."):
-        # https://stackoverflow.com/a/23419450/6578628
-        r = requests.get(BC5CDR_URL)
-        z = zipfile.ZipFile(io.BytesIO(r.content))
+        train_raw, valid_raw, test_raw = _download_corpus()
     msg.good("Downloaded the corpus")
 
-    with msg.loading("Preprocessing the training data..."):
-        raw = z.read(str(Path(PARENT_DIR) / TRAIN_FILENAME)).decode("utf8")
-        train = _preprocess(raw)
-    msg.good("Preprocessed the training data")
-
-    with msg.loading("Preprocessing the validation data..."):
-        raw = z.read(str(Path(PARENT_DIR) / VALID_FILENAME)).decode("utf8")
-        valid = _preprocess(raw)
-    msg.good("Preprocessed the validation data")
-
-    with msg.loading("Preprocessing the test data..."):
-        raw = z.read(str(Path(PARENT_DIR) / TEST_FILENAME)).decode("utf8")
-        test = _preprocess(raw)
-    msg.good("Preprocessed the test data")
+    with msg.loading("Preprocessing the data..."):
+        train = _preprocess(train_raw)
+        valid = _preprocess(valid_raw)
+        test = _preprocess(test_raw)
+    msg.good("Preprocessed the data")
 
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
This PR adds a function for computing corpus statistics, and adds a command for the BC5CDR corpus.

TODOs:

- [ ] Figure out how to set a default typer command.
- [ ] Add `corpus-stats` command for each dataset.