### PR TITLE
Add entity hinting

### DIFF
--- a/seq2rel_ds/preprocess/bc5cdr.py
+++ b/seq2rel_ds/preprocess/bc5cdr.py
@@ -17,18 +17,21 @@ VALID_FILENAME = "CDR_DevelopmentSet.PubTator.txt"
 TEST_FILENAME = "CDR_TestSet.PubTator.txt"
 
 
-def _preprocess(pubtator_content: str) -> List[str]:
+def _preprocess(pubtator_content: str, include_ent_hints: bool = False) -> List[str]:
     pubtator_annotations = util.parse_pubtator(
         pubtator_content=pubtator_content, text_segment=util.TextSegment.both, sort_ents=True
     )
-    seq2rel_annotations = util.pubtator_to_seq2rel(pubtator_annotations)
+    seq2rel_annotations = util.pubtator_to_seq2rel(pubtator_annotations, include_ent_hints)
 
     return seq2rel_annotations
 
 
-@app.callback(invoke_without_command=True)
+@app.command()
 def main(
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
+    include_ent_hints: bool = typer.Option(
+        False, help="Include entity location and type hints in the text"
+    ),
 ) -> None:
     """Preprocess a local copy of the BC5CDR corpus for use with seq2rel."""
     msg.divider("Preprocessing BC5CDR")
@@ -41,17 +44,17 @@ def main(
 
     with msg.loading("Preprocessing the training data..."):
         raw = z.read(str(Path(PARENT_DIR) / TRAIN_FILENAME)).decode("utf8")
-        train = _preprocess(raw)
+        train = _preprocess(raw, include_ent_hints)
     msg.good("Preprocessed the training data")
 
     with msg.loading("Preprocessing the validation data..."):
         raw = z.read(str(Path(PARENT_DIR) / VALID_FILENAME)).decode("utf8")
-        valid = _preprocess(raw)
+        valid = _preprocess(raw, include_ent_hints)
     msg.good("Preprocessed the validation data")
 
     with msg.loading("Preprocessing the test data..."):
         raw = z.read(str(Path(PARENT_DIR) / TEST_FILENAME)).decode("utf8")
-        test = _preprocess(raw)
+        test = _preprocess(raw, include_ent_hints)
     msg.good("Preprocessed the test data")
 
     output_dir = Path(output_dir)

--- a/seq2rel_ds/preprocess/gda.py
+++ b/seq2rel_ds/preprocess/gda.py
@@ -70,9 +70,7 @@ def _convert_to_pubtator(abstracts: str, anns: str, labels: str) -> str:
 
 
 def _preprocess(
-    abstracts: str,
-    anns: str,
-    labels: str,
+    abstracts: str, anns: str, labels: str, include_ent_hints: bool = False
 ) -> List[str]:
 
     pubtator_content = _convert_to_pubtator(abstracts=abstracts, anns=anns, labels=labels)
@@ -80,14 +78,17 @@ def _preprocess(
         pubtator_content=pubtator_content, text_segment=util.TextSegment.both, sort_ents=True
     )
 
-    seq2rel_annotations = util.pubtator_to_seq2rel(pubtator_annotations)
+    seq2rel_annotations = util.pubtator_to_seq2rel(pubtator_annotations, include_ent_hints)
 
     return seq2rel_annotations
 
 
-@app.callback(invoke_without_command=True)
+@app.command()
 def main(
-    output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data.")
+    output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
+    include_ent_hints: bool = typer.Option(
+        False, help="Include entity location and type hints in the text"
+    ),
 ) -> None:
     """Download and preprocess the GDA corpus for use with seq2rel."""
     msg.divider("Preprocessing GDA")
@@ -105,10 +106,10 @@ def main(
     msg.good("Downloaded the test data")
 
     with msg.loading("Preprocessing the training data..."):
-        train = _preprocess(train_abstracts, train_anns, train_labels)
+        train = _preprocess(train_abstracts, train_anns, train_labels, include_ent_hints)
     msg.good("Preprocessed the training data")
     with msg.loading("Preprocessing the test data..."):
-        test = _preprocess(test_abstracts, test_anns, test_labels)
+        test = _preprocess(test_abstracts, test_anns, test_labels, include_ent_hints)
     msg.good("Preprocessed the test data")
 
     train, valid = train_test_split(train, test_size=VALID_SIZE)


### PR DESCRIPTION
This PR adds "entity hinting", which is basically the ability to insert hints as to the location and type of entities within the source text. For example, in the following text we provide hints for two entities, a chemical and a disease, that are involved in a "chemical-induced disease" relationship:

```
We describe a 42-year-old woman who developed superior @START_DISEASE@ sagittal and left transverse sinus thrombosis @END_DISEASE@ associated with prolonged @START_CHEMICAL@ epsilon-aminocaproic acid @END_CHEMICAL@.
```

The purpose of this is so that we can compare to document-level relation extraction techniques that are not joint. I made a couple of decisions here:

1. Only provide hints for the first (unique) occurrence of an entity.
2. Only provide hints for entities involved in a relation.

both of these decisions help limit the amount of additional tokens introduced in the source text.

This functionality is also exposed by the `bc5cdr` and `gda` commands with the flag `--include-ent-hints`. I have not added them for the other commands, because the entity hinting code only works for PubTator formatted text. In the future, I will update all commands to first convert their datasets to the PubTator format, so that we can standardize parsing and postprocessing. Tracking that in #24.

Finally, for whatever reason, adding an option to the `main` `callback` broke things, and so now it has to be a `command` and therefore invoked with `seq2rel-ds preprocess <command> main`. I am tracking this in #25.