### PR TITLE
Change default dgm validation set size

### DIFF
--- a/seq2rel_ds/preprocess/dgm.py
+++ b/seq2rel_ds/preprocess/dgm.py
@@ -98,7 +98,7 @@ def main(
         case_sensitive=False,
     ),
     valid_size: float = typer.Option(
-        0.1,
+        0.2,
         help=(
             "Fraction of training examples to hold out as a validation set. The original validation"
             " set is used as the test set, as the test set does not contain paragraph-level annotations",


### PR DESCRIPTION
Increases the default size of the DGM validation set. This give sus better estimates of performance when we are tuning (at the cost of less training data).