### PR TITLE
Better offsets dgm

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -126,7 +126,7 @@ pyflakes = ">=2.3.0,<2.4.0"
 
 [[package]]
 name = "hypothesis"
-version = "6.40.2"
+version = "6.41.0"
 description = "A library for property-based testing"
 category = "dev"
 optional = false
@@ -502,7 +502,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "803a1e27aadd510fbf243d47dbb4eb8dd9a3f12778d5ec74638bc5e4e427b269"
+content-hash = "abf8572e891494453032360e7c85d19c9bf4b6f0fe095cf3a4550fbad95e8a80"
 
 [metadata.files]
 atomicwrites = [
@@ -622,8 +622,8 @@ flake8 = [
     {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 hypothesis = [
-    {file = "hypothesis-6.40.2-py3-none-any.whl", hash = "sha256:cf2e300b018c1cb0647fabbd4fbbb40bf62bd17be11f82748092c8f9bc034efb"},
-    {file = "hypothesis-6.40.2.tar.gz", hash = "sha256:49e82f9aed63836e5c40081aaa795cffe9f4322f39caa188b903cfd4c6942733"},
+    {file = "hypothesis-6.41.0-py3-none-any.whl", hash = "sha256:ca931c5a6414f3f9636fdaf978a216ee9b5c4a6b4415adf628e9d5e5003dcd99"},
+    {file = "hypothesis-6.41.0.tar.gz", hash = "sha256:de48abb676fc76e4397cd002926e5747cef518570d132221244d27e1075c0bec"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},

--- a/seq2rel_ds/common/text_utils.py
+++ b/seq2rel_ds/common/text_utils.py
@@ -1,5 +1,17 @@
 # Public functions #
 
+from typing import Iterable
+
+
+def findall(string: str, substring: str) -> Iterable[int]:
+    """Find all overlapping occurrences of `substring` in a `string`.
+    Taken from: https://stackoverflow.com/a/34445090/6578628
+    """
+    i = string.find(substring)
+    while i != -1:
+        yield i
+        i = string.find(substring, i + 1)
+
 
 def sanitize_text(text: str, lowercase: bool = False) -> str:
     """Cleans text by removing whitespace, newlines and tabs and (optionally) lowercasing."""

--- a/tests/common/util/test_text_utils.py
+++ b/tests/common/util/test_text_utils.py
@@ -6,6 +6,25 @@ from hypothesis.strategies import booleans, text
 from seq2rel_ds.common import text_utils
 
 
+def test_findall() -> None:
+    # Test a simple case where there is no match.
+    string = "The substring is not here!"
+    substring = "test"
+    assert list(text_utils.findall(string, substring)) == []
+    # Test a simple case where there is one match.
+    string = "The substring is here! test"
+    substring = "test"
+    assert list(text_utils.findall(string, substring)) == [23]
+    # Test a simple case where there is more than one (non-overlapping) match.
+    string = "The substring is here twice! test test"
+    substring = "test"
+    assert list(text_utils.findall(string, substring)) == [29, 34]
+    # Test a simple case where there is more than one (overlapping) match.
+    string = "GATATATGCATATACTT"
+    substring = "ATAT"
+    assert list(text_utils.findall(string, substring)) == [1, 3, 9]
+
+
 @given(text=text(), lowercase=booleans())
 def test_sanitize_text(text: str, lowercase: bool) -> None:
     sanitized_text = text_utils.sanitize_text(text, lowercase=lowercase)


### PR DESCRIPTION
Previously, the character offsets for entity mentions in the `dgm.py` script were just based on the _first_ mention of an entity. This doesn't change the conversion to the seq2rel format but was giving us an incorrect value when I tried to compute the fraction of inter-sentence relations (which relies on character offsets to compute). This PR updates the preprocess so that accurate character offsets are determined for every mention of an entity.