### PR TITLE
:recycle: Change clusters to entities everywhere

### DIFF
--- a/seq2rel_ds/cdr.py
+++ b/seq2rel_ds/cdr.py
@@ -56,8 +56,8 @@ def _filter_hypernyms(pubtator_annotations: List[PubtatorAnnotation]) -> None:
     for annotation in pubtator_annotations:
         if annotation.relations:
             chem_id, diso_id, rel_label = annotation.relations[0]
-            chem_label = annotation.clusters[chem_id].label
-            diso_label = annotation.clusters[diso_id].label
+            chem_label = annotation.entities[chem_id].label
+            diso_label = annotation.entities[diso_id].label
             break
 
     for annotation in pubtator_annotations:
@@ -68,10 +68,10 @@ def _filter_hypernyms(pubtator_annotations: List[PubtatorAnnotation]) -> None:
         # Determine the negative relations by taking the set of the product of all unique chemical
         # and disease entities, minus the set of all positive relations.
         chemicals = [
-            ent_id for ent_id, ann in annotation.clusters.items() if ann.label == chem_label
+            ent_id for ent_id, ann in annotation.entities.items() if ann.label == chem_label
         ]
         diseases = [
-            ent_id for ent_id, ann in annotation.clusters.items() if ann.label == diso_label
+            ent_id for ent_id, ann in annotation.entities.items() if ann.label == diso_label
         ]
         all_relations = [
             (chem, diso, rel_label) for chem, diso in itertools.product(chemicals, diseases)

--- a/seq2rel_ds/common/util.py
+++ b/seq2rel_ds/common/util.py
@@ -14,7 +14,7 @@ from sklearn.model_selection import train_test_split
 from urllib3.util.retry import Retry
 
 from seq2rel_ds.common import sorting_utils
-from seq2rel_ds.common.schemas import PubtatorAnnotation, PubtatorCluster
+from seq2rel_ds.common.schemas import PubtatorAnnotation, PubtatorEntity
 
 # Seeds
 SEED = 13370
@@ -208,11 +208,11 @@ def parse_pubtator(
                         if match is not None:
                             offset = match.span()
 
-                    if uid in parsed[-1].clusters:
-                        parsed[-1].clusters[uid].mentions.append(mention)
-                        parsed[-1].clusters[uid].offsets.append(offset)
+                    if uid in parsed[-1].entities:
+                        parsed[-1].entities[uid].mentions.append(mention)
+                        parsed[-1].entities[uid].offsets.append(offset)
                     else:
-                        parsed[-1].clusters[uid] = PubtatorCluster(
+                        parsed[-1].entities[uid] = PubtatorEntity(
                             mentions=[mention], offsets=[offset], label=label
                         )
             # This is a relation
@@ -222,7 +222,7 @@ def parse_pubtator(
                 # Check that the relations entities are in the text
                 # and that this relation is unique.
                 if rel not in parsed[-1].relations and all(
-                    uid in parsed[-1].clusters for uid in uids
+                    uid in parsed[-1].entities for uid in uids
                 ):
                     parsed[-1].relations.append(rel)
 

--- a/tests/common/test_schemas.py
+++ b/tests/common/test_schemas.py
@@ -7,8 +7,8 @@ from seq2rel_ds.common import schemas
 from seq2rel_ds.common.special_tokens import COREF_SEP_SYMBOL, HINT_SEP_SYMBOL
 
 
-def test_pubtator_cluster_to_string() -> None:
-    ent = schemas.PubtatorCluster(
+def test_pubtator_entity_to_string() -> None:
+    ent = schemas.PubtatorEntity(
         # Contains:
         # - multi-word mentions
         # - overlapping mentions
@@ -40,8 +40,8 @@ def test_pubtator_cluster_to_string() -> None:
     assert COREF_SEP_SYMBOL in actual
 
 
-def test_pubtator_cluster_get_offsets() -> None:
-    ent = schemas.PubtatorCluster(
+def test_pubtator_entity_get_offsets() -> None:
+    ent = schemas.PubtatorEntity(
         # We don't need actual mentions or a label to test this method.
         mentions=[
             "",
@@ -76,13 +76,13 @@ def test_insert_hints() -> None:
     pubator_annotation = schemas.PubtatorAnnotation(
         pmid="12160362",
         text=text,
-        clusters={
-            "348": schemas.PubtatorCluster(
+        entities={
+            "348": schemas.PubtatorEntity(
                 mentions=["Apolipoprotein E", "apolipoprotein E", "apoE"],
                 offsets=[(0, 17), (207, 223), (225, 229)],
                 label="Gene",
             ),
-            "D000544": schemas.PubtatorCluster(
+            "D000544": schemas.PubtatorEntity(
                 mentions=["Alzheimer disease", "Alzheimer disease", "Alzheimer disease"],
                 offsets=[(160, 177), (339, 356), (479, 496)],
                 label="Disease",
@@ -106,11 +106,11 @@ def test_insert_hints_compound() -> None:
     pubator_annotation = schemas.PubtatorAnnotation(
         pmid="9862868",
         text=text,
-        clusters={
-            "D002780": schemas.PubtatorCluster(
+        entities={
+            "D002780": schemas.PubtatorEntity(
                 mentions=["intrahepatic cholestasis"], offsets=[(87, 128)], label="Disease"
             ),
-            "D001651": schemas.PubtatorCluster(
+            "D001651": schemas.PubtatorEntity(
                 mentions=["extrahepatic cholestasis"], offsets=[(104, 128)], label="Disease"
             ),
         },
@@ -133,13 +133,13 @@ def test_insert_hints_overlapping() -> None:
     pubator_annotation = schemas.PubtatorAnnotation(
         pmid="8844208",
         text=text,
-        clusters={
-            "2155": schemas.PubtatorCluster(
+        entities={
+            "2155": schemas.PubtatorEntity(
                 mentions=["coagulation factor VII", "coagulation factor VII"],
                 offsets=[(44, 67), (222, 244)],
                 label="Gene",
             ),
-            "D005168": schemas.PubtatorCluster(
+            "D005168": schemas.PubtatorEntity(
                 mentions=["factor VII deficiency", "factor VII deficiency"],
                 offsets=[(56, 78), (234, 255)],
                 label="Disease",
@@ -166,11 +166,11 @@ def test_insert_hints_no_mutation() -> None:
     pubator_annotation = schemas.PubtatorAnnotation(
         pmid="9862868",
         text=text,
-        clusters={
-            "D002780": schemas.PubtatorCluster(
+        entities={
+            "D002780": schemas.PubtatorEntity(
                 mentions=["intrahepatic cholestasis"], offsets=[(87, 128)], label="Disease"
             ),
-            "D001651": schemas.PubtatorCluster(
+            "D001651": schemas.PubtatorEntity(
                 mentions=["extrahepatic cholestasis"], offsets=[(104, 128)], label="Disease"
             ),
         },
@@ -181,7 +181,7 @@ def test_insert_hints_no_mutation() -> None:
 
     assert pubator_annotation.text != expected.text
     assert pubator_annotation.pmid == expected.pmid
-    assert pubator_annotation.clusters == expected.clusters
+    assert pubator_annotation.entities == expected.entities
     assert pubator_annotation.relations == expected.relations
 
 
@@ -195,23 +195,23 @@ def test_pubtator_annotation_to_string() -> None:
         # We don't need text or a PMID to test this method.
         pmid="",
         text="",
-        clusters={
-            "D008094": schemas.PubtatorCluster(
+        entities={
+            "D008094": schemas.PubtatorEntity(
                 mentions=["lithium", "lithium", "Li", "Li"],
                 offsets=[(54, 61), (111, 118), (941, 943), (1333, 1335)],
                 label="Chemical",
             ),
-            "D006973": schemas.PubtatorCluster(
+            "D006973": schemas.PubtatorEntity(
                 mentions=["hypertension", "hypertension"],
                 offsets=[(1000, 1012), (1500, 1512)],
                 label="Disease",
             ),
-            "D011507": schemas.PubtatorCluster(
+            "D011507": schemas.PubtatorEntity(
                 mentions=["proteinuria", "proteinuria"],
                 offsets=[(975, 986), (1466, 1477)],
                 label="Disease",
             ),
-            "D007676": schemas.PubtatorCluster(
+            "D007676": schemas.PubtatorEntity(
                 mentions=["chronic renal failure", "chronic renal failure"],
                 offsets=[(70, 91), (1531, 1552)],
                 label="Disease",
@@ -268,6 +268,6 @@ def test_as_pubtator_annotation(dummy_annotation_json) -> None:
     actual = json.loads(dummy_annotation_json, object_hook=schemas.as_pubtator_annotation)
     assert isinstance(actual.pmid, str)
     assert isinstance(actual, schemas.PubtatorAnnotation)
-    for uid, cluster in actual.clusters.items():
+    for uid, ent in actual.entities.items():
         assert isinstance(uid, str)
-        assert isinstance(cluster, schemas.PubtatorCluster)
+        assert isinstance(ent, schemas.PubtatorEntity)

--- a/tests/common/util/test_common_util.py
+++ b/tests/common/util/test_common_util.py
@@ -100,66 +100,66 @@ def test_parse_pubtator() -> None:
     {pmid}\tCID\tD001569\tD005221
     """
 
-    title_clusters = {
-        "D001569": schemas.PubtatorCluster(
+    title_entities = {
+        "D001569": schemas.PubtatorEntity(
             mentions=["benzodiazepines"],
             offsets=[(28, 43)],
             label="Chemical",
         ),
     }
-    abstract_clusters = {
-        "D001569": schemas.PubtatorCluster(
+    abstract_entities = {
+        "D001569": schemas.PubtatorEntity(
             mentions=["benzodiazepines", "BZDs", "BZDs"],
             offsets=[(219, 234), (253, 257), (583, 587)],
             label="Chemical",
         ),
-        "D005221": schemas.PubtatorCluster(
+        "D005221": schemas.PubtatorEntity(
             mentions=["tiredness"], offsets=[(1817, 1826)], label="Disease"
         ),
     }
-    both_clusters = {
-        "D001569": schemas.PubtatorCluster(
-            mentions=title_clusters["D001569"].mentions + abstract_clusters["D001569"].mentions,
-            offsets=title_clusters["D001569"].offsets + abstract_clusters["D001569"].offsets,
+    both_entities = {
+        "D001569": schemas.PubtatorEntity(
+            mentions=title_entities["D001569"].mentions + abstract_entities["D001569"].mentions,
+            offsets=title_entities["D001569"].offsets + abstract_entities["D001569"].offsets,
             label="Chemical",
         ),
-        "D005221": schemas.PubtatorCluster(
+        "D005221": schemas.PubtatorEntity(
             mentions=["tiredness"], offsets=[(1817, 1826)], label="Disease"
         ),
     }
 
     # Title only
     expected = schemas.PubtatorAnnotation(
-        pmid=pmid, text=title_text, clusters=title_clusters, relations=[]
+        pmid=pmid, text=title_text, entities=title_entities, relations=[]
     )
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.title)
     # Breaking up the asserts leads to much clearer outputs when the test fails
     assert actual[0].text == expected.text
-    assert actual[0].clusters == expected.clusters
+    assert actual[0].entities == expected.entities
     assert actual[0].relations == expected.relations
 
     # Abstract only
     expected = schemas.PubtatorAnnotation(
         pmid=pmid,
         text=abstract_text,
-        clusters=abstract_clusters,
+        entities=abstract_entities,
         relations=[("D001569", "D005221", "CID")],
     )
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.abstract)
     assert actual[0].text == expected.text
-    assert actual[0].clusters == expected.clusters
+    assert actual[0].entities == expected.entities
     assert actual[0].relations == expected.relations
 
     # Both
     expected = schemas.PubtatorAnnotation(
         pmid=pmid,
         text=f"{title_text} {abstract_text}",
-        clusters=both_clusters,
+        entities=both_entities,
         relations=[("D001569", "D005221", "CID")],
     )
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.both)
     assert actual[0].text == expected.text
-    assert actual[0].clusters == expected.clusters
+    assert actual[0].entities == expected.entities
     assert actual[0].relations == expected.relations
 
 
@@ -232,21 +232,21 @@ def test_parse_pubtator_compound_ent() -> None:
     expected = schemas.PubtatorAnnotation(
         pmid=pmid,
         text=f"{title_text} {abstract_text}",
-        clusters={
-            "D019259": schemas.PubtatorCluster(
+        entities={
+            "D019259": schemas.PubtatorEntity(
                 mentions=["lamivudine"],
                 offsets=[(26, 36)],
                 label="Chemical",
             ),
-            "D012964": schemas.PubtatorCluster(
+            "D012964": schemas.PubtatorEntity(
                 mentions=["na"], offsets=[(59, 61)], label="Chemical"
             ),
-            "D006509": schemas.PubtatorCluster(
+            "D006509": schemas.PubtatorEntity(
                 mentions=["hepatitis B virus (HBV) infected", "HBV infected"],
                 offsets=[(66, 98), (186, 209)],
                 label="Disease",
             ),
-            "D015658": schemas.PubtatorCluster(
+            "D015658": schemas.PubtatorEntity(
                 mentions=["HIV co-infection", "HIV infected"],
                 offsets=[(125, 141), (194, 209)],
                 label="Disease",
@@ -255,7 +255,7 @@ def test_parse_pubtator_compound_ent() -> None:
     )
     actual = util.parse_pubtator(pubtator_content, text_segment=util.TextSegment.both)
     assert actual[0].text == expected.text
-    assert actual[0].clusters == expected.clusters
+    assert actual[0].entities == expected.entities
     assert actual[0].relations == expected.relations
 
 
@@ -280,22 +280,22 @@ def test_query_pubtator() -> None:
         " mitochondria. These findings suggest that RNF5 negatively regulates virus-triggered"
         " signaling by targeting MITA for ubiquitination and degradation at the mitochondria."
     )
-    title_clusters = {
-        "6048": schemas.PubtatorCluster(
+    title_entities = {
+        "6048": schemas.PubtatorEntity(
             mentions=["RNF5"],
             offsets=[(21, 25)],
             label="Gene",
         ),
-        "340061": schemas.PubtatorCluster(mentions=["MITA"], offsets=[(104, 108)], label="Gene"),
+        "340061": schemas.PubtatorEntity(mentions=["MITA"], offsets=[(104, 108)], label="Gene"),
     }
-    abstract_clusters = {
-        "4790": schemas.PubtatorCluster(mentions=["NF-kappaB"], offsets=[(158, 167)], label="Gene"),
-        "3661": schemas.PubtatorCluster(
+    abstract_entities = {
+        "4790": schemas.PubtatorEntity(mentions=["NF-kappaB"], offsets=[(158, 167)], label="Gene"),
+        "3661": schemas.PubtatorEntity(
             mentions=["IRF3", "IRF3", "IRF3"],
             offsets=[(172, 176), (378, 382), (554, 558)],
             label="Gene",
         ),
-        "340061": schemas.PubtatorCluster(
+        "340061": schemas.PubtatorEntity(
             mentions=["MITA", "STING", "MITA", "MITA", "MITA", "MITA", "MITA"],
             offsets=[
                 (270, 274),
@@ -308,7 +308,7 @@ def test_query_pubtator() -> None:
             ],
             label="Gene",
         ),
-        "6048": schemas.PubtatorCluster(
+        "6048": schemas.PubtatorEntity(
             mentions=["RNF5", "RNF5", "RNF5", "RNF5", "RNF5", "RNF5", "RNF5"],
             offsets=[
                 (440, 444),
@@ -321,31 +321,31 @@ def test_query_pubtator() -> None:
             ],
             label="Gene",
         ),
-        "3456": schemas.PubtatorCluster(mentions=["IFNB1"], offsets=[(571, 576)], label="Gene"),
+        "3456": schemas.PubtatorEntity(mentions=["IFNB1"], offsets=[(571, 576)], label="Gene"),
     }
-    both_clusters = {
-        "6048": schemas.PubtatorCluster(
-            mentions=title_clusters["6048"].mentions + abstract_clusters["6048"].mentions,
-            offsets=title_clusters["6048"].offsets + abstract_clusters["6048"].offsets,
+    both_entities = {
+        "6048": schemas.PubtatorEntity(
+            mentions=title_entities["6048"].mentions + abstract_entities["6048"].mentions,
+            offsets=title_entities["6048"].offsets + abstract_entities["6048"].offsets,
             label="Gene",
         ),
-        "340061": schemas.PubtatorCluster(
-            mentions=title_clusters["340061"].mentions + abstract_clusters["340061"].mentions,
-            offsets=title_clusters["340061"].offsets + abstract_clusters["340061"].offsets,
+        "340061": schemas.PubtatorEntity(
+            mentions=title_entities["340061"].mentions + abstract_entities["340061"].mentions,
+            offsets=title_entities["340061"].offsets + abstract_entities["340061"].offsets,
             label="Gene",
         ),
-        "4790": schemas.PubtatorCluster(mentions=["NF-kappaB"], offsets=[(158, 167)], label="Gene"),
-        "3661": schemas.PubtatorCluster(
-            mentions=abstract_clusters["3661"].mentions,
-            offsets=abstract_clusters["3661"].offsets,
+        "4790": schemas.PubtatorEntity(mentions=["NF-kappaB"], offsets=[(158, 167)], label="Gene"),
+        "3661": schemas.PubtatorEntity(
+            mentions=abstract_entities["3661"].mentions,
+            offsets=abstract_entities["3661"].offsets,
             label="Gene",
         ),
-        "3456": schemas.PubtatorCluster(mentions=["IFNB1"], offsets=[(571, 576)], label="Gene"),
+        "3456": schemas.PubtatorEntity(mentions=["IFNB1"], offsets=[(571, 576)], label="Gene"),
     }
 
     # Title only
     expected = schemas.PubtatorAnnotation(
-        pmid=pmid, text=title_text, clusters=title_clusters, relations=[]
+        pmid=pmid, text=title_text, entities=title_entities, relations=[]
     )
     actual = util.query_pubtator(
         pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.title
@@ -353,29 +353,29 @@ def test_query_pubtator() -> None:
     # Breaking up the asserts leads to much clearer outputs when the test fails
     assert len(actual) == 1
     assert actual[expected.pmid].text == expected.text
-    assert actual[expected.pmid].clusters == expected.clusters
+    assert actual[expected.pmid].entities == expected.entities
     assert actual[expected.pmid].relations == expected.relations
 
     # Abstract only
     expected = schemas.PubtatorAnnotation(
-        pmid=pmid, text=abstract_text, clusters=abstract_clusters, relations=[]
+        pmid=pmid, text=abstract_text, entities=abstract_entities, relations=[]
     )
     actual = util.query_pubtator(
         pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.abstract
     )
     assert len(actual) == 1
     assert actual[expected.pmid].text == expected.text
-    assert actual[expected.pmid].clusters == expected.clusters
+    assert actual[expected.pmid].entities == expected.entities
     assert actual[expected.pmid].relations == expected.relations
 
     # Both
     expected = schemas.PubtatorAnnotation(
-        pmid=pmid, text=f"{title_text} {abstract_text}", clusters=both_clusters, relations=[]
+        pmid=pmid, text=f"{title_text} {abstract_text}", entities=both_entities, relations=[]
     )
     actual = util.query_pubtator(
         pmids=[pmid], concepts=["gene"], text_segment=util.TextSegment.both
     )
     assert len(actual) == 1
     assert actual[expected.pmid].text == expected.text
-    assert actual[expected.pmid].clusters == expected.clusters
+    assert actual[expected.pmid].entities == expected.entities
     assert actual[expected.pmid].relations == expected.relations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ def dummy_annotation_dict() -> Dict[str, Any]:
             "Mutations of yeast CYC8 or TUP1 genes greatly reduce the degree of glucose repression"
             " of many genes and affect other regulatory pathways, including mating type."
         ),
-        "clusters": {
+        "entities": {
             "852410": {"mentions": ["cyc8"], "offsets": [[142, 146]], "label": "Gene"},
             "850445": {"mentions": ["tup1"], "offsets": [[150, 154]], "label": "Gene"},
         },

--- a/tests/preprocess/test_cdr.py
+++ b/tests/preprocess/test_cdr.py
@@ -89,23 +89,23 @@ class TestCDR(Seq2RelDSTestCase):
                 " literature review of all previously reported cases."
             ),
             pmid="",
-            clusters={
-                "D002220": schemas.PubtatorCluster(
+            entities={
+                "D002220": schemas.PubtatorEntity(
                     mentions=["Carbamazepine", "carbamazepine"],
                     offsets=[(0, 13), (115, 128)],
                     label="Chemical",
                 ),
-                "D006331": schemas.PubtatorCluster(
+                "D006331": schemas.PubtatorEntity(
                     mentions=["cardiac dysfunction"],
                     offsets=[(22, 41)],
                     label="Disease",
                 ),
-                "D001919": schemas.PubtatorCluster(
+                "D001919": schemas.PubtatorEntity(
                     mentions=["bradycardia"],
                     offsets=[(64, 75)],
                     label="Disease",
                 ),
-                "D054537": schemas.PubtatorCluster(
+                "D054537": schemas.PubtatorEntity(
                     mentions=["atrioventricular block"],
                     offsets=[(80, 102)],
                     label="Disease",


### PR DESCRIPTION
This PR renames the `clusters` attribute of `PubtatorAnnotation` to `entities`. Likewise, it renames `PubtatorCluster` --> `PubtatorEntity`. This is a breaking change and any code that depend on previous versions of this library will need to be updated. The motivation for the name change is that, "entities" is more commonly used than "clusters" and should be more immediately intuitive.

Closes #45.