### PR TITLE
:sparkles: Set default command for each dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,8 @@ seq2rel-ds --help
 To preprocess a dataset (and in most cases, download it), call one of the commands, e.g.
 
 ```bash
-seq2rel-ds preprocess cdr main "path/to/cdr"
+seq2rel-ds cdr "path/to/cdr"
 ```
-
-> Note, you have to include `main` because [`typer`](https://typer.tiangolo.com/) does not support default commands.
 
 This will create the preprocessed `tsv` files under the specified output directory, e.g.
 

--- a/seq2rel_ds/cdr.py
+++ b/seq2rel_ds/cdr.py
@@ -124,7 +124,7 @@ def _preprocess(
     return seq2rel_annotations
 
 
-@app.command()
+@app.callback(invoke_without_command=True)
 def main(
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
     sort_rels: bool = typer.Option(

--- a/seq2rel_ds/dgm.py
+++ b/seq2rel_ds/dgm.py
@@ -87,7 +87,7 @@ def _preprocess(
     return seq2rel_annotations
 
 
-@app.command()
+@app.callback(invoke_without_command=True)
 def main(
     input_dir: Path = typer.Argument(..., help="Path to a local copy of the DGM corpus."),
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
@@ -111,6 +111,7 @@ def main(
     ),
 ) -> None:
     """Download and preprocess the DGM corpus for use with seq2rel.
+
     The corpus can be downloaded at: https://hanover.azurewebsites.net/downloads/naacl2019.aspx.
     Provide this path as argument `input_dir` to this command. More details about the corpus can be
     found here: https://arxiv.org/abs/1904.02347. Note that we use the paragraph-length text.

--- a/seq2rel_ds/docred.py
+++ b/seq2rel_ds/docred.py
@@ -83,7 +83,7 @@ def _preprocess(
     return seq2rel_annotations
 
 
-@app.command()
+@app.callback(invoke_without_command=True)
 def main(
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
     sort_rels: bool = typer.Option(

--- a/seq2rel_ds/docred.py
+++ b/seq2rel_ds/docred.py
@@ -90,7 +90,11 @@ def main(
         True, help="Sort relations according to order of first appearance."
     ),
 ) -> None:
-    """Download and preprocess the DocRED corpus for use with seq2rel."""
+    """Download and preprocess the DocRED corpus for use with seq2rel.
+
+    This is the end-to-end split provided by https://arxiv.org/abs/2102.05980, which can be
+    accessed here: http://lavis.cs.hs-rm.de/storage/jerex/public/datasets/docred_joint/.
+    """
     msg.divider("Preprocessing DocRED")
 
     with msg.loading("Downloading corpus..."):

--- a/seq2rel_ds/gda.py
+++ b/seq2rel_ds/gda.py
@@ -106,7 +106,7 @@ def _preprocess(
     return seq2rel_annotations
 
 
-@app.command()
+@app.callback(invoke_without_command=True)
 def main(
     output_dir: Path = typer.Argument(..., help="Directory path to save the preprocessed data."),
     sort_rels: bool = typer.Option(


### PR DESCRIPTION
# Overview

This PR sets the default command for each of the dataset scripts. This allows us to drop the call to `main`. E.g. where before it was:

```bash
seq2rel-ds cdr "path/to/cdr"
```

it is now

```
seq2rel-ds cdr main "path/to/cdr"
```

I found the solution [here](https://cloudbytes.dev/snippets/set-the-default-command-in-python-typer-cli).

## Other changes

- :books: Updates the docstring of the `docred` command to specify that we are downloading the end-to-end split.

## Closes

Closes #25.