### PR TITLE
:wrench: Support py3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7.13, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 exclude = ["tests", "test_fixtures"]
 
 [tool.poetry.dependencies]
-python = "^3.7.1"
+python = "^3.7.13"
 typer = {extras = ["all"], version = "^0.4.1"}
 more-itertools = "^8.10.0"
 wasabi = "^0.8.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 exclude = ["tests", "test_fixtures"]
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7.1"
 typer = {extras = ["all"], version = "^0.4.1"}
 more-itertools = "^8.10.0"
 wasabi = "^0.8.2"


### PR DESCRIPTION
I had originally dropped support for py3.7 in #53 but it turns out this is still the version of python used by Google Colab. Adding back in support so that we can host tutorial notebooks on Colab.